### PR TITLE
Input validation

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -606,6 +606,29 @@
     },
     "FlightBooking": {
       "description": "Allows automating airplane tickets booking and collecting related information.",
+      "input": {
+        "properties": {
+          "url": {
+            "$ref": "#Generic.URL",
+          },
+          "flight": {
+            "$ref": "#FlightBooking.Flight",
+          },
+          "account": {
+            "$ref": "#Generic.Account",
+          },
+          "passengers": {
+            "$ref": "#FlightBooking.Passengers",
+          },
+          "payment": {
+            "$ref": "#Generic.Payment",
+          },
+          "finalPriceConsent": {
+            "$ref": "#Generic.PriceConsent",
+          }
+        },
+        "additionalProperties": false
+      }
       "inputs": {
         "url": {
           "$ref": "#Generic.URL",

--- a/schema.json
+++ b/schema.json
@@ -628,7 +628,7 @@
           }
         },
         "additionalProperties": false
-      }
+      },
       "inputs": {
         "url": {
           "$ref": "#Generic.URL",


### PR DESCRIPTION
We should communicate schema for initial input object. We should also be able to validate provided input or generate random input using some sub-schema of a protocol.

Also, very important point is to be able to communicate deferred-only input in contrast of flexible input: we do not expect fields like cabin class, selected seat of pin code from account to be provided upfront, but we don't communicate that, currently. It is possible to communicate that if we separate base input definition from inputs and make it so it works like a schema (it just saves a bit of  overhead for building an input schema from the protocol).

This PR is not for merging (it is incomplete), the only purpose of this code is to demonstrate code change behind the idea, using FlightBooking domain as an example.