### PR TITLE
Add flight search, retire flight itinerary

### DIFF
--- a/docs/build/app.js
+++ b/docs/build/app.js
@@ -38330,8 +38330,8 @@ module.exports={
             "type": "object",
             "description": "Outbound and inbound flights specification.",
             "properties": {
-                "origin": { "$ref": "#/domains/FlightBooking/types/DatePlace" },
-                "destination": { "$ref": "#/domains/FlightBooking/types/DatePlace" }
+                "origin": { "$ref": "#/domains/FlightBooking/types/DateTimeAirport" },
+                "destination": { "$ref": "#/domains/FlightBooking/types/DateTimeAirport" }
             },
             "required": [
                 "origin",
@@ -38372,7 +38372,7 @@ module.exports={
             ],
             "additionalProperties": false
         },
-        "DatePlace": {
+        "DateTimeAirport": {
             "type": "object",
             "properties": {
                 "dateTime": {

--- a/docs/build/app.js
+++ b/docs/build/app.js
@@ -38223,6 +38223,7 @@ module.exports={
         "itinerary": {
             "typeRef": "#/domains/FlightBooking/types/Itinerary",
             "initial": true,
+            "description": "Deprecated. See <a href=\"#search\">/search</a> and <a href=\"#selectedOutboundFlight\">/selectedOutboundFlight</a>.",
             "deprecated": true
         },
         "account": {
@@ -38300,7 +38301,7 @@ module.exports={
         },
         "Itinerary": {
             "type": "object",
-            "description": "Information about flights and cabin class preference.",
+            "description": "Deprecated. See <a href=\"#Search\">Search</a> and <a href=\"#FlightSearch\">FlightSearch</a> instead.<br/>Information about flights and cabin class preference.",
             "deprecated": true,
             "properties": {
                 "cabinClass": {

--- a/docs/build/app.js
+++ b/docs/build/app.js
@@ -38211,6 +38211,10 @@ module.exports={
         "selectedInboundFlight": {
             "typeRef": "#/domains/FlightBooking/types/Flight"
         },
+        "itinerary": {
+            "typeRef": "#/domains/FlightBooking/types/Itinerary",
+            "initial": true
+        },
         "account": {
             "typeRef": "#/domains/Generic/types/Account",
             "initial": true
@@ -38283,6 +38287,29 @@ module.exports={
                     "default": false
                 }
             }
+        },
+        "Itinerary": {
+            "type": "object",
+            "description": "Information about flights and cabin class preference.",
+            "properties": {
+                "cabinClass": {
+                    "$ref": "#/domains/FlightBooking/types/CabinClass",
+                    "description": "Preferred cabin class, used on flight search forms."
+                },
+                "outbound": {
+                    "$ref": "#/domains/FlightBooking/types/Flight",
+                    "description": "Outbound flight specification."
+                },
+                "inbound": {
+                    "$ref": "#/domains/FlightBooking/types/Flight",
+                    "description": "Inbound (return) flight specification. If omitted, one-way flight booking flow is used."
+                }
+            },
+            "required": [
+                "cabinClass",
+                "outbound"
+            ],
+            "additionalProperties": false
         },
         "Search": {
             "type": "object",

--- a/docs/build/app.js
+++ b/docs/build/app.js
@@ -36914,9 +36914,9 @@ if (module.hot) {(function () {  var hotAPI = require("vue-hot-reload-api")
   module.hot.accept()
   module.hot.dispose(__vueify_style_dispose__)
   if (!module.hot.data) {
-    hotAPI.createRecord("data-v-3a814de9", __vue__options__)
+    hotAPI.createRecord("data-v-19d51b2e", __vue__options__)
   } else {
-    hotAPI.reload("data-v-3a814de9", __vue__options__)
+    hotAPI.reload("data-v-19d51b2e", __vue__options__)
   }
 })()}
 },{"vue":135,"vue-hot-reload-api":133,"vueify/lib/insert-css":136}],139:[function(require,module,exports){
@@ -36949,6 +36949,11 @@ module.exports = {
         pii() {
             const { pii } = this.def.spec;
             return !!pii;
+        },
+
+        deprecated() {
+            const { deprecated } = this.def.spec;
+            return !!deprecated;
         }
     },
 
@@ -36965,7 +36970,7 @@ module.exports = {
 if (module.exports.__esModule) module.exports = module.exports.default
 var __vue__options__ = (typeof module.exports === "function"? module.exports.options: module.exports)
 if (__vue__options__.functional) {console.error("[vueify] functional components are not supported and should be defined in plain js files using render functions.")}
-__vue__options__.render = function render () {var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;return _c('div',{staticClass:"def",class:{ 'def--active': _vm.active },attrs:{"id":_vm.def.key}},[_c('h3',{staticClass:"def__header"},[_c('span',{staticClass:"def__id"},[_vm._v(_vm._s(_vm.def.id))]),_vm._v(" "),(_vm.pii)?_c('span',{staticClass:"tag tag--primary",attrs:{"title":"Personally identifiable information"}},[_vm._v("\n            PII\n        ")]):_vm._e(),_vm._v(" "),_c('img',{staticClass:"def__link",attrs:{"src":"/img/link.svg"},on:{"click":_vm.permalink}})]),_vm._v(" "),_c('div',{staticClass:"def__type"},[_c('schema-type',{attrs:{"spec":_vm.def.spec}}),_vm._v(" "),(_vm.loose)?_c('span',{staticClass:"tag tag--warning"},[_vm._v("\n            allows additional properties\n        ")]):_vm._e()],1),_vm._v(" "),_c('div',{staticClass:"def__description",domProps:{"innerHTML":_vm._s(_vm.def.spec.description)}}),_vm._v(" "),(_vm.def.spec.enum)?[_c('h4',[_vm._v("Allowed values")]),_vm._v(" "),_c('div',{staticClass:"def__enum"},[_vm._v("\n            "+_vm._s(_vm.def.spec.enum.join(', '))+"\n        ")])]:_vm._e(),_vm._v(" "),(_vm.def.spec.properties)?[_c('h4',[_vm._v("Properties")]),_vm._v(" "),_vm._l((_vm.def.spec.properties),function(prop,id){return _c('prop',{staticClass:"def__prop",attrs:{"id":id,"prop":prop,"parent":_vm.def}})})]:_vm._e()],2)}
+__vue__options__.render = function render () {var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;return _c('div',{staticClass:"def",class:{ 'def--active': _vm.active },attrs:{"id":_vm.def.key}},[_c('h3',{staticClass:"def__header"},[_c('span',{staticClass:"def__id"},[_vm._v(_vm._s(_vm.def.id))]),_vm._v(" "),(_vm.pii)?_c('span',{staticClass:"tag tag--primary",attrs:{"title":"Personally identifiable information"}},[_vm._v("\n            PII\n        ")]):_vm._e(),_vm._v(" "),(_vm.deprecated)?_c('span',{staticClass:"tag tag--warning"},[_vm._v("\n            deprecated\n        ")]):_vm._e(),_vm._v(" "),_c('img',{staticClass:"def__link",attrs:{"src":"/img/link.svg"},on:{"click":_vm.permalink}})]),_vm._v(" "),_c('div',{staticClass:"def__type"},[_c('schema-type',{attrs:{"spec":_vm.def.spec}}),_vm._v(" "),(_vm.loose)?_c('span',{staticClass:"tag tag--warning"},[_vm._v("\n            allows additional properties\n        ")]):_vm._e()],1),_vm._v(" "),_c('div',{staticClass:"def__description",domProps:{"innerHTML":_vm._s(_vm.def.spec.description)}}),_vm._v(" "),(_vm.def.spec.enum)?[_c('h4',[_vm._v("Allowed values")]),_vm._v(" "),_c('div',{staticClass:"def__enum"},[_vm._v("\n            "+_vm._s(_vm.def.spec.enum.join(', '))+"\n        ")])]:_vm._e(),_vm._v(" "),(_vm.def.spec.properties)?[_c('h4',[_vm._v("Properties")]),_vm._v(" "),_vm._l((_vm.def.spec.properties),function(prop,id){return _c('prop',{staticClass:"def__prop",attrs:{"id":id,"prop":prop,"parent":_vm.def}})})]:_vm._e()],2)}
 __vue__options__.staticRenderFns = []
 if (module.hot) {(function () {  var hotAPI = require("vue-hot-reload-api")
   hotAPI.install(require("vue"), true)
@@ -36973,9 +36978,9 @@ if (module.hot) {(function () {  var hotAPI = require("vue-hot-reload-api")
   module.hot.accept()
   module.hot.dispose(__vueify_style_dispose__)
   if (!module.hot.data) {
-    hotAPI.createRecord("data-v-0a99ee74", __vue__options__)
+    hotAPI.createRecord("data-v-7ccc0c18", __vue__options__)
   } else {
-    hotAPI.reload("data-v-0a99ee74", __vue__options__)
+    hotAPI.reload("data-v-7ccc0c18", __vue__options__)
   }
 })()}
 },{"./prop.vue":142,"./schema-type.vue":143,"vue":135,"vue-hot-reload-api":133,"vueify/lib/insert-css":136}],140:[function(require,module,exports){
@@ -37020,9 +37025,9 @@ if (module.hot) {(function () {  var hotAPI = require("vue-hot-reload-api")
   module.hot.accept()
   module.hot.dispose(__vueify_style_dispose__)
   if (!module.hot.data) {
-    hotAPI.createRecord("data-v-127f07de", __vue__options__)
+    hotAPI.createRecord("data-v-766ccc5e", __vue__options__)
   } else {
-    hotAPI.reload("data-v-127f07de", __vue__options__)
+    hotAPI.reload("data-v-766ccc5e", __vue__options__)
   }
 })()}
 },{"vue":135,"vue-hot-reload-api":133,"vueify/lib/insert-css":136}],141:[function(require,module,exports){
@@ -37074,7 +37079,7 @@ var __vue__options__ = (typeof module.exports === "function"? module.exports.opt
 if (__vue__options__.functional) {console.error("[vueify] functional components are not supported and should be defined in plain js files using render functions.")}
 __vue__options__.render = function render () {var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;return _c('div',{staticClass:"oneliner",class:{
          'oneliner--active': _vm.active,
-     },attrs:{"id":_vm.def.key}},[_c('div',{staticClass:"oneliner__term"},[_c('span',{staticClass:"oneliner__key"},[_vm._v(_vm._s(_vm.def.key))]),_vm._v(" "),_c('img',{staticClass:"oneliner__link",attrs:{"src":"/img/link.svg"},on:{"click":_vm.permalink}}),_vm._v(" "),_c('div',{staticClass:"oneliner__details"},[(_vm.def.spec.initial)?_c('span',{staticClass:"tag tag--success"},[_vm._v("\n                initial\n            ")]):_vm._e(),_vm._v(" "),(_vm.def.spec.staged)?_c('span',{staticClass:"tag tag--primary"},[_vm._v("\n                staged\n            ")]):_vm._e()])]),_vm._v(" "),_c('div',{staticClass:"oneliner__body"},[_c('schema-type',{attrs:{"spec":_vm.def.spec}}),_vm._v(" "),_c('div',{staticClass:"oneliner__description",domProps:{"innerHTML":_vm._s(_vm.description)}}),_vm._v(" "),(typeof _vm.def.spec.default !== 'undefined')?_c('div',{staticClass:"oneliner__default"},[_c('strong',[_vm._v("Default value:")]),_vm._v(" "),_c('val',{attrs:{"value":_vm.def.spec.default}})],1):_vm._e()],1)])}
+     },attrs:{"id":_vm.def.key}},[_c('div',{staticClass:"oneliner__term"},[_c('span',{staticClass:"oneliner__key"},[_vm._v(_vm._s(_vm.def.key))]),_vm._v(" "),_c('img',{staticClass:"oneliner__link",attrs:{"src":"/img/link.svg"},on:{"click":_vm.permalink}}),_vm._v(" "),_c('div',{staticClass:"oneliner__details"},[(_vm.def.spec.initial)?_c('span',{staticClass:"tag tag--success"},[_vm._v("\n                initial\n            ")]):_vm._e(),_vm._v(" "),(_vm.def.spec.staged)?_c('span',{staticClass:"tag tag--primary"},[_vm._v("\n                staged\n            ")]):_vm._e(),_vm._v(" "),(_vm.def.spec.deprecated)?_c('span',{staticClass:"tag tag--warning"},[_vm._v("\n                deprecated\n            ")]):_vm._e()])]),_vm._v(" "),_c('div',{staticClass:"oneliner__body"},[_c('schema-type',{attrs:{"spec":_vm.def.spec}}),_vm._v(" "),_c('div',{staticClass:"oneliner__description",domProps:{"innerHTML":_vm._s(_vm.description)}}),_vm._v(" "),(typeof _vm.def.spec.default !== 'undefined')?_c('div',{staticClass:"oneliner__default"},[_c('strong',[_vm._v("Default value:")]),_vm._v(" "),_c('val',{attrs:{"value":_vm.def.spec.default}})],1):_vm._e()],1)])}
 __vue__options__.staticRenderFns = []
 if (module.hot) {(function () {  var hotAPI = require("vue-hot-reload-api")
   hotAPI.install(require("vue"), true)
@@ -37082,9 +37087,9 @@ if (module.hot) {(function () {  var hotAPI = require("vue-hot-reload-api")
   module.hot.accept()
   module.hot.dispose(__vueify_style_dispose__)
   if (!module.hot.data) {
-    hotAPI.createRecord("data-v-66f512f9", __vue__options__)
+    hotAPI.createRecord("data-v-a09f910e", __vue__options__)
   } else {
-    hotAPI.reload("data-v-66f512f9", __vue__options__)
+    hotAPI.reload("data-v-a09f910e", __vue__options__)
   }
 })()}
 },{"./schema-type.vue":143,"./val.vue":144,"vue":135,"vue-hot-reload-api":133,"vueify/lib/insert-css":136}],142:[function(require,module,exports){
@@ -37127,9 +37132,9 @@ if (module.hot) {(function () {  var hotAPI = require("vue-hot-reload-api")
   module.hot.accept()
   module.hot.dispose(__vueify_style_dispose__)
   if (!module.hot.data) {
-    hotAPI.createRecord("data-v-2c8015f8", __vue__options__)
+    hotAPI.createRecord("data-v-12c15984", __vue__options__)
   } else {
-    hotAPI.reload("data-v-2c8015f8", __vue__options__)
+    hotAPI.reload("data-v-12c15984", __vue__options__)
   }
 })()}
 },{"./schema-type.vue":143,"./val.vue":144,"vue":135,"vue-hot-reload-api":133,"vueify/lib/insert-css":136}],143:[function(require,module,exports){
@@ -37163,6 +37168,10 @@ module.exports = {
 
         pii() {
             return !!this.ref.spec.pii;
+        },
+
+        deprecated() {
+            return !!this.ref.spec.deprecated;
         }
 
     }
@@ -37178,7 +37187,7 @@ __vue__options__.render = function render () {var _vm=this;var _h=_vm.$createEle
                         domainId: _vm.ref.domain.id,
                     },
                     hash: '#' + _vm.ref.key,
-                }}},[_vm._v("\n                "+_vm._s(_vm.ref.id)+"\n            ")]):_c('span',{staticClass:"schema-type__broken-ref"},[_vm._v("\n                "+_vm._s(_vm.$ref)+"\n            ")])],1):_vm._e(),_vm._v(" "),(_vm.pii)?_c('span',{staticClass:"tag tag--primary",attrs:{"title":"Personally identifiable information"}},[_vm._v("\n            PII\n        ")]):_vm._e()]],2)}
+                }}},[_vm._v("\n                "+_vm._s(_vm.ref.id)+"\n            ")]):_c('span',{staticClass:"schema-type__broken-ref"},[_vm._v("\n                "+_vm._s(_vm.$ref)+"\n            ")])],1):_vm._e(),_vm._v(" "),(_vm.pii)?_c('span',{staticClass:"tag tag--primary",attrs:{"title":"Personally identifiable information"}},[_vm._v("\n            PII\n        ")]):_vm._e(),_vm._v(" "),(_vm.deprecated)?_c('span',{staticClass:"tag tag--warning"},[_vm._v("\n            deprecated\n        ")]):_vm._e()]],2)}
 __vue__options__.staticRenderFns = []
 if (module.hot) {(function () {  var hotAPI = require("vue-hot-reload-api")
   hotAPI.install(require("vue"), true)
@@ -37186,9 +37195,9 @@ if (module.hot) {(function () {  var hotAPI = require("vue-hot-reload-api")
   module.hot.accept()
   module.hot.dispose(__vueify_style_dispose__)
   if (!module.hot.data) {
-    hotAPI.createRecord("data-v-4afe22d5", __vue__options__)
+    hotAPI.createRecord("data-v-14faae55", __vue__options__)
   } else {
-    hotAPI.reload("data-v-4afe22d5", __vue__options__)
+    hotAPI.reload("data-v-14faae55", __vue__options__)
   }
 })()}
 },{"../../src":156,"vue":135,"vue-hot-reload-api":133,"vueify/lib/insert-css":136}],144:[function(require,module,exports){
@@ -37234,9 +37243,9 @@ if (module.hot) {(function () {  var hotAPI = require("vue-hot-reload-api")
   if (!hotAPI.compatible) return
   module.hot.accept()
   if (!module.hot.data) {
-    hotAPI.createRecord("data-v-876978e0", __vue__options__)
+    hotAPI.createRecord("data-v-734b4f10", __vue__options__)
   } else {
-    hotAPI.reload("data-v-876978e0", __vue__options__)
+    hotAPI.reload("data-v-734b4f10", __vue__options__)
   }
 })()}
 },{"vue":135,"vue-hot-reload-api":133}],145:[function(require,module,exports){
@@ -37361,9 +37370,9 @@ if (module.hot) {(function () {  var hotAPI = require("vue-hot-reload-api")
   module.hot.accept()
   module.hot.dispose(__vueify_style_dispose__)
   if (!module.hot.data) {
-    hotAPI.createRecord("data-v-ff742a1e", __vue__options__)
+    hotAPI.createRecord("data-v-2b566f71", __vue__options__)
   } else {
-    hotAPI.reload("data-v-ff742a1e", __vue__options__)
+    hotAPI.reload("data-v-2b566f71", __vue__options__)
   }
 })()}
 },{"../../src":156,"../components/def.vue":139,"../components/error-oneliner.vue":140,"../components/oneliner.vue":141,"../util":151,"vue":135,"vue-hot-reload-api":133,"vueify/lib/insert-css":136}],147:[function(require,module,exports){
@@ -37376,9 +37385,9 @@ if (module.hot) {(function () {  var hotAPI = require("vue-hot-reload-api")
   if (!hotAPI.compatible) return
   module.hot.accept()
   if (!module.hot.data) {
-    hotAPI.createRecord("data-v-5ac5e6cc", __vue__options__)
+    hotAPI.createRecord("data-v-012d8b4c", __vue__options__)
   } else {
-    hotAPI.reload("data-v-5ac5e6cc", __vue__options__)
+    hotAPI.reload("data-v-012d8b4c", __vue__options__)
   }
 })()}
 },{"vue":135,"vue-hot-reload-api":133}],148:[function(require,module,exports){
@@ -37405,9 +37414,9 @@ if (module.hot) {(function () {  var hotAPI = require("vue-hot-reload-api")
   module.hot.accept()
   module.hot.dispose(__vueify_style_dispose__)
   if (!module.hot.data) {
-    hotAPI.createRecord("data-v-42712352", __vue__options__)
+    hotAPI.createRecord("data-v-ec501a52", __vue__options__)
   } else {
-    hotAPI.reload("data-v-42712352", __vue__options__)
+    hotAPI.reload("data-v-ec501a52", __vue__options__)
   }
 })()}
 },{"./sidebar.vue":149,"vue":135,"vue-hot-reload-api":133,"vueify/lib/insert-css":136}],149:[function(require,module,exports){
@@ -37442,9 +37451,9 @@ if (module.hot) {(function () {  var hotAPI = require("vue-hot-reload-api")
   module.hot.accept()
   module.hot.dispose(__vueify_style_dispose__)
   if (!module.hot.data) {
-    hotAPI.createRecord("data-v-6c64fcff", __vue__options__)
+    hotAPI.createRecord("data-v-2365087f", __vue__options__)
   } else {
-    hotAPI.reload("data-v-6c64fcff", __vue__options__)
+    hotAPI.reload("data-v-2365087f", __vue__options__)
   }
 })()}
 },{"../../src":156,"./sidebar__domain.vue":150,"vue":135,"vue-hot-reload-api":133,"vueify/lib/insert-css":136}],150:[function(require,module,exports){
@@ -37513,9 +37522,9 @@ if (module.hot) {(function () {  var hotAPI = require("vue-hot-reload-api")
   module.hot.accept()
   module.hot.dispose(__vueify_style_dispose__)
   if (!module.hot.data) {
-    hotAPI.createRecord("data-v-7f822ca3", __vue__options__)
+    hotAPI.createRecord("data-v-497eb823", __vue__options__)
   } else {
-    hotAPI.reload("data-v-7f822ca3", __vue__options__)
+    hotAPI.reload("data-v-497eb823", __vue__options__)
   }
 })()}
 },{"vue":135,"vue-hot-reload-api":133,"vueify/lib/insert-css":136}],151:[function(require,module,exports){
@@ -38213,7 +38222,8 @@ module.exports={
         },
         "itinerary": {
             "typeRef": "#/domains/FlightBooking/types/Itinerary",
-            "initial": true
+            "initial": true,
+            "deprecated": true
         },
         "account": {
             "typeRef": "#/domains/Generic/types/Account",
@@ -38291,6 +38301,7 @@ module.exports={
         "Itinerary": {
             "type": "object",
             "description": "Information about flights and cabin class preference.",
+            "deprecated": true,
             "properties": {
                 "cabinClass": {
                     "$ref": "#/domains/FlightBooking/types/CabinClass",

--- a/docs/build/app.js
+++ b/docs/build/app.js
@@ -38100,6 +38100,16 @@ module.exports={
             "description": "Website entry point. Should be a deep link to either flight page or flight selection page.",
             "initial": true
         },
+        "search": {
+            "typeRef": "#/domains/FlightBooking/types/Search",
+            "initial": true
+        },
+        "selectedOutboundFlight": {
+            "typeRef": "#/domains/FlightBooking/types/Flight"
+        },
+        "selectedInboundFlight": {
+            "typeRef": "#/domains/FlightBooking/types/Flight"
+        },
         "itinerary": {
             "typeRef": "#/domains/FlightBooking/types/Itinerary",
             "initial": true
@@ -38200,6 +38210,48 @@ module.exports={
             ],
             "additionalProperties": false
         },
+        "Search": {
+            "type": "object",
+            "description": "Information about flights and cabin class preference.",
+            "properties": {
+                "cabinClass": {
+                    "$ref": "#/domains/FlightBooking/types/CabinClass",
+                    "description": "Preferred cabin class, used on flight search forms."
+                },
+                "outbound": {
+                    "$ref": "#/domains/FlightBooking/types/FlightSearch",
+                    "description": "Outbound flight specification."
+                },
+                "inbound": {
+                    "$ref": "#/domains/FlightBooking/types/FlightSearch",
+                    "description": "Inbound (return) flight specification. If omitted, one-way flight booking flow is used."
+                },
+                "passengerAges": {
+                    "typeRef": "#/domains/Generic/types/Ages",
+                    "description": "Ages of all passengers.",
+                    "example": [34, 31, 9]
+                }
+            },
+            "required": [
+                "cabinClass",
+                "outbound",
+                "passengerAges"
+            ],
+            "additionalProperties": false
+        },
+        "FlightSearch": {
+            "type": "object",
+            "description": "Outbound and inbound flights specification.",
+            "properties": {
+                "origin": { "$ref": "#/domains/FlightBooking/types/DateAirport" },
+                "destination": { "$ref": "#/domains/FlightBooking/types/DateAirport" }
+            },
+            "required": [
+                "origin",
+                "destination"
+            ],
+            "additionalProperties": false
+        },
         "Flight": {
             "type": "object",
             "description": "Outbound and inbound flights specification.",
@@ -38216,6 +38268,35 @@ module.exports={
         "CabinClass": {
             "type": "string",
             "enum": ["economy", "premium economy", "business", "first"]
+        },
+        "DateAirport": {
+            "type": "object",
+            "properties": {
+                "date": {
+                    "type": "string",
+                    "format": "date",
+                    "description": "Date of flight (airport local date).",
+                    "example": "2019-01-01"
+                },
+                "airportCode": {
+                    "type": "string",
+                    "minLength": 3,
+                    "maxLength": 3,
+                    "pattern": "^[A-Z]{3}$",
+                    "description": "International Air Transport Association airport code.",
+                    "example": "SFO"
+                },
+                "countryCode": {
+                    "$ref": "#/domains/Generic/types/CountryCode",
+                    "description": "Country code of airport.",
+                    "example": "us"
+                }
+            },
+            "required": [
+                "date",
+                "airportCode"
+            ],
+            "additionalProperties": false
         },
         "DatePlace": {
             "type": "object",
@@ -38491,6 +38572,16 @@ module.exports={
     "inputs": {},
     "outputs": {},
     "types": {
+        "Ages": {
+            "type": "array",
+            "description": "A list of ages of persons.",
+            "items": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 200,
+                "example": 42
+            }
+        },
         "URL": {
             "type": "string",
             "format": "url",
@@ -39459,7 +39550,8 @@ module.exports={
             "initial": true
         },
         "guestAges": {
-            "typeRef": "#/domains/VacationRental/types/GuestAges",
+            "typeRef": "#/domains/Generic/types/Ages",
+            "description": "Ages of all guests.",
             "initial": true
         },
         "account": {
@@ -39536,15 +39628,6 @@ module.exports={
                 "name",
                 "price"
             ]
-        },
-        "GuestAges": {
-            "type": "array",
-            "items": {
-                "type": "number",
-                "minimum": 0,
-                "maximum": 200,
-                "example": 42
-            }
         },
         "Pets": {
             "type": "object",

--- a/docs/build/app.js
+++ b/docs/build/app.js
@@ -38110,10 +38110,6 @@ module.exports={
         "selectedInboundFlight": {
             "typeRef": "#/domains/FlightBooking/types/Flight"
         },
-        "itinerary": {
-            "typeRef": "#/domains/FlightBooking/types/Itinerary",
-            "initial": true
-        },
         "account": {
             "typeRef": "#/domains/Generic/types/Account",
             "initial": true
@@ -38186,29 +38182,6 @@ module.exports={
                     "default": false
                 }
             }
-        },
-        "Itinerary": {
-            "type": "object",
-            "description": "Information about flights and cabin class preference.",
-            "properties": {
-                "cabinClass": {
-                    "$ref": "#/domains/FlightBooking/types/CabinClass",
-                    "description": "Preferred cabin class, used on flight search forms."
-                },
-                "outbound": {
-                    "$ref": "#/domains/FlightBooking/types/Flight",
-                    "description": "Outbound flight specification."
-                },
-                "inbound": {
-                    "$ref": "#/domains/FlightBooking/types/Flight",
-                    "description": "Inbound (return) flight specification. If omitted, one-way flight booking flow is used."
-                }
-            },
-            "required": [
-                "cabinClass",
-                "outbound"
-            ],
-            "additionalProperties": false
         },
         "Search": {
             "type": "object",

--- a/docs/index.html
+++ b/docs/index.html
@@ -14,7 +14,7 @@
     <body>
         <div id="app">
         </div>
-        <script src="/build/app.js?1518696719504">
+        <script src="/build/app.js?1519036499808">
         </script>
     </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -14,7 +14,7 @@
     <body>
         <div id="app">
         </div>
-        <script src="/build/app.js?1518424800883">
+        <script src="/build/app.js?1518424841589">
         </script>
     </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -14,7 +14,7 @@
     <body>
         <div id="app">
         </div>
-        <script src="/build/app.js?1518696004471">
+        <script src="/build/app.js?1518696719504">
         </script>
     </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -14,7 +14,7 @@
     <body>
         <div id="app">
         </div>
-        <script src="/build/app.js?1518524903071">
+        <script src="/build/app.js?1518544387003">
         </script>
     </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -14,7 +14,7 @@
     <body>
         <div id="app">
         </div>
-        <script src="/build/app.js?1518452747950">
+        <script src="/build/app.js?1518452838385">
         </script>
     </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -14,7 +14,7 @@
     <body>
         <div id="app">
         </div>
-        <script src="/build/app.js?1517915126347">
+        <script src="/build/app.js?1518424800883">
         </script>
     </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -14,7 +14,7 @@
     <body>
         <div id="app">
         </div>
-        <script src="/build/app.js?1518544387003">
+        <script src="/build/app.js?1518545109433">
         </script>
     </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -14,7 +14,7 @@
     <body>
         <div id="app">
         </div>
-        <script src="/build/app.js?1518452838385">
+        <script src="/build/app.js?1518524903071">
         </script>
     </body>
 </html>

--- a/docs/schema.json
+++ b/docs/schema.json
@@ -831,6 +831,10 @@
         "selectedInboundFlight": {
           "typeRef": "#/domains/FlightBooking/types/Flight"
         },
+        "itinerary": {
+          "typeRef": "#/domains/FlightBooking/types/Itinerary",
+          "initial": true
+        },
         "account": {
           "typeRef": "#/domains/Generic/types/Account",
           "initial": true
@@ -903,6 +907,29 @@
               "default": false
             }
           }
+        },
+        "Itinerary": {
+          "type": "object",
+          "description": "Information about flights and cabin class preference.",
+          "properties": {
+            "cabinClass": {
+              "$ref": "#/domains/FlightBooking/types/CabinClass",
+              "description": "Preferred cabin class, used on flight search forms."
+            },
+            "outbound": {
+              "$ref": "#/domains/FlightBooking/types/Flight",
+              "description": "Outbound flight specification."
+            },
+            "inbound": {
+              "$ref": "#/domains/FlightBooking/types/Flight",
+              "description": "Inbound (return) flight specification. If omitted, one-way flight booking flow is used."
+            }
+          },
+          "required": [
+            "cabinClass",
+            "outbound"
+          ],
+          "additionalProperties": false
         },
         "Search": {
           "type": "object",

--- a/docs/schema.json
+++ b/docs/schema.json
@@ -959,10 +959,10 @@
           "description": "Outbound and inbound flights specification.",
           "properties": {
             "origin": {
-              "$ref": "#/domains/FlightBooking/types/DatePlace"
+              "$ref": "#/domains/FlightBooking/types/DateTimeAirport"
             },
             "destination": {
-              "$ref": "#/domains/FlightBooking/types/DatePlace"
+              "$ref": "#/domains/FlightBooking/types/DateTimeAirport"
             }
           },
           "required": [
@@ -1009,7 +1009,7 @@
           ],
           "additionalProperties": false
         },
-        "DatePlace": {
+        "DateTimeAirport": {
           "type": "object",
           "properties": {
             "dateTime": {

--- a/docs/schema.json
+++ b/docs/schema.json
@@ -7,6 +7,16 @@
       "inputs": {},
       "outputs": {},
       "types": {
+        "Ages": {
+          "type": "array",
+          "description": "A list of ages of persons.",
+          "items": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 200,
+            "example": 42
+          }
+        },
         "URL": {
           "type": "string",
           "format": "url",
@@ -718,6 +728,16 @@
           "description": "Website entry point. Should be a deep link to either flight page or flight selection page.",
           "initial": true
         },
+        "search": {
+          "typeRef": "#/domains/FlightBooking/types/Search",
+          "initial": true
+        },
+        "selectedOutboundFlight": {
+          "typeRef": "#/domains/FlightBooking/types/Flight"
+        },
+        "selectedInboundFlight": {
+          "typeRef": "#/domains/FlightBooking/types/Flight"
+        },
         "itinerary": {
           "typeRef": "#/domains/FlightBooking/types/Itinerary",
           "initial": true
@@ -818,6 +838,56 @@
           ],
           "additionalProperties": false
         },
+        "Search": {
+          "type": "object",
+          "description": "Information about flights and cabin class preference.",
+          "properties": {
+            "cabinClass": {
+              "$ref": "#/domains/FlightBooking/types/CabinClass",
+              "description": "Preferred cabin class, used on flight search forms."
+            },
+            "outbound": {
+              "$ref": "#/domains/FlightBooking/types/FlightSearch",
+              "description": "Outbound flight specification."
+            },
+            "inbound": {
+              "$ref": "#/domains/FlightBooking/types/FlightSearch",
+              "description": "Inbound (return) flight specification. If omitted, one-way flight booking flow is used."
+            },
+            "passengerAges": {
+              "typeRef": "#/domains/Generic/types/Ages",
+              "description": "Ages of all passengers.",
+              "example": [
+                34,
+                31,
+                9
+              ]
+            }
+          },
+          "required": [
+            "cabinClass",
+            "outbound",
+            "passengerAges"
+          ],
+          "additionalProperties": false
+        },
+        "FlightSearch": {
+          "type": "object",
+          "description": "Outbound and inbound flights specification.",
+          "properties": {
+            "origin": {
+              "$ref": "#/domains/FlightBooking/types/DateAirport"
+            },
+            "destination": {
+              "$ref": "#/domains/FlightBooking/types/DateAirport"
+            }
+          },
+          "required": [
+            "origin",
+            "destination"
+          ],
+          "additionalProperties": false
+        },
         "Flight": {
           "type": "object",
           "description": "Outbound and inbound flights specification.",
@@ -843,6 +913,35 @@
             "business",
             "first"
           ]
+        },
+        "DateAirport": {
+          "type": "object",
+          "properties": {
+            "date": {
+              "type": "string",
+              "format": "date",
+              "description": "Date of flight (airport local date).",
+              "example": "2019-01-01"
+            },
+            "airportCode": {
+              "type": "string",
+              "minLength": 3,
+              "maxLength": 3,
+              "pattern": "^[A-Z]{3}$",
+              "description": "International Air Transport Association airport code.",
+              "example": "SFO"
+            },
+            "countryCode": {
+              "$ref": "#/domains/Generic/types/CountryCode",
+              "description": "Country code of airport.",
+              "example": "us"
+            }
+          },
+          "required": [
+            "date",
+            "airportCode"
+          ],
+          "additionalProperties": false
         },
         "DatePlace": {
           "type": "object",
@@ -1142,7 +1241,8 @@
           "initial": true
         },
         "guestAges": {
-          "typeRef": "#/domains/VacationRental/types/GuestAges",
+          "typeRef": "#/domains/Generic/types/Ages",
+          "description": "Ages of all guests.",
           "initial": true
         },
         "account": {
@@ -1223,15 +1323,6 @@
             "name",
             "price"
           ]
-        },
-        "GuestAges": {
-          "type": "array",
-          "items": {
-            "type": "number",
-            "minimum": 0,
-            "maximum": 200,
-            "example": 42
-          }
         },
         "Pets": {
           "type": "object",

--- a/docs/schema.json
+++ b/docs/schema.json
@@ -833,7 +833,8 @@
         },
         "itinerary": {
           "typeRef": "#/domains/FlightBooking/types/Itinerary",
-          "initial": true
+          "initial": true,
+          "deprecated": true
         },
         "account": {
           "typeRef": "#/domains/Generic/types/Account",
@@ -911,6 +912,7 @@
         "Itinerary": {
           "type": "object",
           "description": "Information about flights and cabin class preference.",
+          "deprecated": true,
           "properties": {
             "cabinClass": {
               "$ref": "#/domains/FlightBooking/types/CabinClass",

--- a/docs/schema.json
+++ b/docs/schema.json
@@ -835,6 +835,7 @@
         "itinerary": {
           "typeRef": "#/domains/FlightBooking/types/Itinerary",
           "initial": true,
+          "description": "Deprecated. See <a href=\"#search\">/search</a> and <a href=\"#selectedOutboundFlight\">/selectedOutboundFlight</a>.",
           "deprecated": true
         },
         "account": {
@@ -912,7 +913,7 @@
         },
         "Itinerary": {
           "type": "object",
-          "description": "Information about flights and cabin class preference.",
+          "description": "Deprecated. See <a href=\"#Search\">Search</a> and <a href=\"#FlightSearch\">FlightSearch</a> instead.<br/>Information about flights and cabin class preference.",
           "deprecated": true,
           "properties": {
             "cabinClass": {

--- a/docs/schema.json
+++ b/docs/schema.json
@@ -738,10 +738,6 @@
         "selectedInboundFlight": {
           "typeRef": "#/domains/FlightBooking/types/Flight"
         },
-        "itinerary": {
-          "typeRef": "#/domains/FlightBooking/types/Itinerary",
-          "initial": true
-        },
         "account": {
           "typeRef": "#/domains/Generic/types/Account",
           "initial": true
@@ -814,29 +810,6 @@
               "default": false
             }
           }
-        },
-        "Itinerary": {
-          "type": "object",
-          "description": "Information about flights and cabin class preference.",
-          "properties": {
-            "cabinClass": {
-              "$ref": "#/domains/FlightBooking/types/CabinClass",
-              "description": "Preferred cabin class, used on flight search forms."
-            },
-            "outbound": {
-              "$ref": "#/domains/FlightBooking/types/Flight",
-              "description": "Outbound flight specification."
-            },
-            "inbound": {
-              "$ref": "#/domains/FlightBooking/types/Flight",
-              "description": "Inbound (return) flight specification. If omitted, one-way flight booking flow is used."
-            }
-          },
-          "required": [
-            "cabinClass",
-            "outbound"
-          ],
-          "additionalProperties": false
         },
         "Search": {
           "type": "object",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ubio/protocol",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "ubio Automation Protocol",
   "main": "src/index.js",
   "author": "ubio",

--- a/schema.json
+++ b/schema.json
@@ -831,6 +831,10 @@
         "selectedInboundFlight": {
           "typeRef": "#/domains/FlightBooking/types/Flight"
         },
+        "itinerary": {
+          "typeRef": "#/domains/FlightBooking/types/Itinerary",
+          "initial": true
+        },
         "account": {
           "typeRef": "#/domains/Generic/types/Account",
           "initial": true
@@ -903,6 +907,29 @@
               "default": false
             }
           }
+        },
+        "Itinerary": {
+          "type": "object",
+          "description": "Information about flights and cabin class preference.",
+          "properties": {
+            "cabinClass": {
+              "$ref": "#/domains/FlightBooking/types/CabinClass",
+              "description": "Preferred cabin class, used on flight search forms."
+            },
+            "outbound": {
+              "$ref": "#/domains/FlightBooking/types/Flight",
+              "description": "Outbound flight specification."
+            },
+            "inbound": {
+              "$ref": "#/domains/FlightBooking/types/Flight",
+              "description": "Inbound (return) flight specification. If omitted, one-way flight booking flow is used."
+            }
+          },
+          "required": [
+            "cabinClass",
+            "outbound"
+          ],
+          "additionalProperties": false
         },
         "Search": {
           "type": "object",

--- a/schema.json
+++ b/schema.json
@@ -959,10 +959,10 @@
           "description": "Outbound and inbound flights specification.",
           "properties": {
             "origin": {
-              "$ref": "#/domains/FlightBooking/types/DatePlace"
+              "$ref": "#/domains/FlightBooking/types/DateTimeAirport"
             },
             "destination": {
-              "$ref": "#/domains/FlightBooking/types/DatePlace"
+              "$ref": "#/domains/FlightBooking/types/DateTimeAirport"
             }
           },
           "required": [
@@ -1009,7 +1009,7 @@
           ],
           "additionalProperties": false
         },
-        "DatePlace": {
+        "DateTimeAirport": {
           "type": "object",
           "properties": {
             "dateTime": {

--- a/schema.json
+++ b/schema.json
@@ -7,6 +7,16 @@
       "inputs": {},
       "outputs": {},
       "types": {
+        "Ages": {
+          "type": "array",
+          "description": "A list of ages of persons.",
+          "items": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 200,
+            "example": 42
+          }
+        },
         "URL": {
           "type": "string",
           "format": "url",
@@ -718,6 +728,16 @@
           "description": "Website entry point. Should be a deep link to either flight page or flight selection page.",
           "initial": true
         },
+        "search": {
+          "typeRef": "#/domains/FlightBooking/types/Search",
+          "initial": true
+        },
+        "selectedOutboundFlight": {
+          "typeRef": "#/domains/FlightBooking/types/Flight"
+        },
+        "selectedInboundFlight": {
+          "typeRef": "#/domains/FlightBooking/types/Flight"
+        },
         "itinerary": {
           "typeRef": "#/domains/FlightBooking/types/Itinerary",
           "initial": true
@@ -818,6 +838,56 @@
           ],
           "additionalProperties": false
         },
+        "Search": {
+          "type": "object",
+          "description": "Information about flights and cabin class preference.",
+          "properties": {
+            "cabinClass": {
+              "$ref": "#/domains/FlightBooking/types/CabinClass",
+              "description": "Preferred cabin class, used on flight search forms."
+            },
+            "outbound": {
+              "$ref": "#/domains/FlightBooking/types/FlightSearch",
+              "description": "Outbound flight specification."
+            },
+            "inbound": {
+              "$ref": "#/domains/FlightBooking/types/FlightSearch",
+              "description": "Inbound (return) flight specification. If omitted, one-way flight booking flow is used."
+            },
+            "passengerAges": {
+              "typeRef": "#/domains/Generic/types/Ages",
+              "description": "Ages of all passengers.",
+              "example": [
+                34,
+                31,
+                9
+              ]
+            }
+          },
+          "required": [
+            "cabinClass",
+            "outbound",
+            "passengerAges"
+          ],
+          "additionalProperties": false
+        },
+        "FlightSearch": {
+          "type": "object",
+          "description": "Outbound and inbound flights specification.",
+          "properties": {
+            "origin": {
+              "$ref": "#/domains/FlightBooking/types/DateAirport"
+            },
+            "destination": {
+              "$ref": "#/domains/FlightBooking/types/DateAirport"
+            }
+          },
+          "required": [
+            "origin",
+            "destination"
+          ],
+          "additionalProperties": false
+        },
         "Flight": {
           "type": "object",
           "description": "Outbound and inbound flights specification.",
@@ -843,6 +913,35 @@
             "business",
             "first"
           ]
+        },
+        "DateAirport": {
+          "type": "object",
+          "properties": {
+            "date": {
+              "type": "string",
+              "format": "date",
+              "description": "Date of flight (airport local date).",
+              "example": "2019-01-01"
+            },
+            "airportCode": {
+              "type": "string",
+              "minLength": 3,
+              "maxLength": 3,
+              "pattern": "^[A-Z]{3}$",
+              "description": "International Air Transport Association airport code.",
+              "example": "SFO"
+            },
+            "countryCode": {
+              "$ref": "#/domains/Generic/types/CountryCode",
+              "description": "Country code of airport.",
+              "example": "us"
+            }
+          },
+          "required": [
+            "date",
+            "airportCode"
+          ],
+          "additionalProperties": false
         },
         "DatePlace": {
           "type": "object",
@@ -1142,7 +1241,8 @@
           "initial": true
         },
         "guestAges": {
-          "typeRef": "#/domains/VacationRental/types/GuestAges",
+          "typeRef": "#/domains/Generic/types/Ages",
+          "description": "Ages of all guests.",
           "initial": true
         },
         "account": {
@@ -1223,15 +1323,6 @@
             "name",
             "price"
           ]
-        },
-        "GuestAges": {
-          "type": "array",
-          "items": {
-            "type": "number",
-            "minimum": 0,
-            "maximum": 200,
-            "example": 42
-          }
         },
         "Pets": {
           "type": "object",

--- a/schema.json
+++ b/schema.json
@@ -833,7 +833,8 @@
         },
         "itinerary": {
           "typeRef": "#/domains/FlightBooking/types/Itinerary",
-          "initial": true
+          "initial": true,
+          "deprecated": true
         },
         "account": {
           "typeRef": "#/domains/Generic/types/Account",
@@ -911,6 +912,7 @@
         "Itinerary": {
           "type": "object",
           "description": "Information about flights and cabin class preference.",
+          "deprecated": true,
           "properties": {
             "cabinClass": {
               "$ref": "#/domains/FlightBooking/types/CabinClass",

--- a/schema.json
+++ b/schema.json
@@ -835,6 +835,7 @@
         "itinerary": {
           "typeRef": "#/domains/FlightBooking/types/Itinerary",
           "initial": true,
+          "description": "Deprecated. See <a href=\"#search\">/search</a> and <a href=\"#selectedOutboundFlight\">/selectedOutboundFlight</a>.",
           "deprecated": true
         },
         "account": {
@@ -912,7 +913,7 @@
         },
         "Itinerary": {
           "type": "object",
-          "description": "Information about flights and cabin class preference.",
+          "description": "Deprecated. See <a href=\"#Search\">Search</a> and <a href=\"#FlightSearch\">FlightSearch</a> instead.<br/>Information about flights and cabin class preference.",
           "deprecated": true,
           "properties": {
             "cabinClass": {

--- a/schema.json
+++ b/schema.json
@@ -738,10 +738,6 @@
         "selectedInboundFlight": {
           "typeRef": "#/domains/FlightBooking/types/Flight"
         },
-        "itinerary": {
-          "typeRef": "#/domains/FlightBooking/types/Itinerary",
-          "initial": true
-        },
         "account": {
           "typeRef": "#/domains/Generic/types/Account",
           "initial": true
@@ -814,29 +810,6 @@
               "default": false
             }
           }
-        },
-        "Itinerary": {
-          "type": "object",
-          "description": "Information about flights and cabin class preference.",
-          "properties": {
-            "cabinClass": {
-              "$ref": "#/domains/FlightBooking/types/CabinClass",
-              "description": "Preferred cabin class, used on flight search forms."
-            },
-            "outbound": {
-              "$ref": "#/domains/FlightBooking/types/Flight",
-              "description": "Outbound flight specification."
-            },
-            "inbound": {
-              "$ref": "#/domains/FlightBooking/types/Flight",
-              "description": "Inbound (return) flight specification. If omitted, one-way flight booking flow is used."
-            }
-          },
-          "required": [
-            "cabinClass",
-            "outbound"
-          ],
-          "additionalProperties": false
         },
         "Search": {
           "type": "object",

--- a/site/components/def.vue
+++ b/site/components/def.vue
@@ -10,6 +10,10 @@
                 v-if="pii">
                 PII
             </span>
+            <span class="tag tag--warning"
+                v-if="deprecated">
+                deprecated
+            </span>
             <img
                 src="/img/link.svg"
                 class="def__link"
@@ -72,6 +76,11 @@ module.exports = {
         pii() {
             const { pii } = this.def.spec;
             return !!pii;
+        },
+
+        deprecated() {
+            const { deprecated } = this.def.spec;
+            return !!deprecated;
         },
     },
 

--- a/site/components/oneliner.vue
+++ b/site/components/oneliner.vue
@@ -19,6 +19,10 @@
                     v-if="def.spec.staged">
                     staged
                 </span>
+                <span class="tag tag--warning"
+                    v-if="def.spec.deprecated">
+                    deprecated
+                </span>
             </div>
         </div>
         <div class="oneliner__body">

--- a/site/components/schema-type.vue
+++ b/site/components/schema-type.vue
@@ -39,6 +39,10 @@
                 v-if="pii">
                 PII
             </span>
+            <span class="tag tag--warning"
+                v-if="deprecated">
+                deprecated
+            </span>
         </template>
     </span>
 </template>
@@ -70,6 +74,10 @@ module.exports = {
 
         pii() {
             return !!this.ref.spec.pii;
+        },
+
+        deprecated() {
+            return !!this.ref.spec.deprecated;
         },
 
     },

--- a/src/meta.json
+++ b/src/meta.json
@@ -74,6 +74,9 @@
                 "initial": {
                     "type": "boolean"
                 },
+                "deprecated": {
+                    "type": "boolean"
+                },
                 "staged": {
                     "type": "boolean"
                 }

--- a/src/schema/flight-booking.json
+++ b/src/schema/flight-booking.json
@@ -22,6 +22,10 @@
         "selectedInboundFlight": {
             "typeRef": "#/domains/FlightBooking/types/Flight"
         },
+        "itinerary": {
+            "typeRef": "#/domains/FlightBooking/types/Itinerary",
+            "initial": true
+        },
         "account": {
             "typeRef": "#/domains/Generic/types/Account",
             "initial": true
@@ -94,6 +98,29 @@
                     "default": false
                 }
             }
+        },
+        "Itinerary": {
+            "type": "object",
+            "description": "Information about flights and cabin class preference.",
+            "properties": {
+                "cabinClass": {
+                    "$ref": "#/domains/FlightBooking/types/CabinClass",
+                    "description": "Preferred cabin class, used on flight search forms."
+                },
+                "outbound": {
+                    "$ref": "#/domains/FlightBooking/types/Flight",
+                    "description": "Outbound flight specification."
+                },
+                "inbound": {
+                    "$ref": "#/domains/FlightBooking/types/Flight",
+                    "description": "Inbound (return) flight specification. If omitted, one-way flight booking flow is used."
+                }
+            },
+            "required": [
+                "cabinClass",
+                "outbound"
+            ],
+            "additionalProperties": false
         },
         "Search": {
             "type": "object",

--- a/src/schema/flight-booking.json
+++ b/src/schema/flight-booking.json
@@ -25,6 +25,7 @@
         "itinerary": {
             "typeRef": "#/domains/FlightBooking/types/Itinerary",
             "initial": true,
+            "description": "Deprecated. See <a href=\"#search\">/search</a> and <a href=\"#selectedOutboundFlight\">/selectedOutboundFlight</a>.",
             "deprecated": true
         },
         "account": {
@@ -102,7 +103,7 @@
         },
         "Itinerary": {
             "type": "object",
-            "description": "Information about flights and cabin class preference.",
+            "description": "Deprecated. See <a href=\"#Search\">Search</a> and <a href=\"#FlightSearch\">FlightSearch</a> instead.<br/>Information about flights and cabin class preference.",
             "deprecated": true,
             "properties": {
                 "cabinClass": {

--- a/src/schema/flight-booking.json
+++ b/src/schema/flight-booking.json
@@ -24,7 +24,8 @@
         },
         "itinerary": {
             "typeRef": "#/domains/FlightBooking/types/Itinerary",
-            "initial": true
+            "initial": true,
+            "deprecated": true
         },
         "account": {
             "typeRef": "#/domains/Generic/types/Account",
@@ -102,6 +103,7 @@
         "Itinerary": {
             "type": "object",
             "description": "Information about flights and cabin class preference.",
+            "deprecated": true,
             "properties": {
                 "cabinClass": {
                     "$ref": "#/domains/FlightBooking/types/CabinClass",

--- a/src/schema/flight-booking.json
+++ b/src/schema/flight-booking.json
@@ -12,6 +12,16 @@
             "description": "Website entry point. Should be a deep link to either flight page or flight selection page.",
             "initial": true
         },
+        "search": {
+            "typeRef": "#/domains/FlightBooking/types/Search",
+            "initial": true
+        },
+        "selectedOutboundFlight": {
+            "typeRef": "#/domains/FlightBooking/types/Flight"
+        },
+        "selectedInboundFlight": {
+            "typeRef": "#/domains/FlightBooking/types/Flight"
+        },
         "itinerary": {
             "typeRef": "#/domains/FlightBooking/types/Itinerary",
             "initial": true
@@ -112,6 +122,48 @@
             ],
             "additionalProperties": false
         },
+        "Search": {
+            "type": "object",
+            "description": "Information about flights and cabin class preference.",
+            "properties": {
+                "cabinClass": {
+                    "$ref": "#/domains/FlightBooking/types/CabinClass",
+                    "description": "Preferred cabin class, used on flight search forms."
+                },
+                "outbound": {
+                    "$ref": "#/domains/FlightBooking/types/FlightSearch",
+                    "description": "Outbound flight specification."
+                },
+                "inbound": {
+                    "$ref": "#/domains/FlightBooking/types/FlightSearch",
+                    "description": "Inbound (return) flight specification. If omitted, one-way flight booking flow is used."
+                },
+                "passengerAges": {
+                    "typeRef": "#/domains/Generic/types/Ages",
+                    "description": "Ages of all passengers.",
+                    "example": [34, 31, 9]
+                }
+            },
+            "required": [
+                "cabinClass",
+                "outbound",
+                "passengerAges"
+            ],
+            "additionalProperties": false
+        },
+        "FlightSearch": {
+            "type": "object",
+            "description": "Outbound and inbound flights specification.",
+            "properties": {
+                "origin": { "$ref": "#/domains/FlightBooking/types/DateAirport" },
+                "destination": { "$ref": "#/domains/FlightBooking/types/DateAirport" }
+            },
+            "required": [
+                "origin",
+                "destination"
+            ],
+            "additionalProperties": false
+        },
         "Flight": {
             "type": "object",
             "description": "Outbound and inbound flights specification.",
@@ -128,6 +180,35 @@
         "CabinClass": {
             "type": "string",
             "enum": ["economy", "premium economy", "business", "first"]
+        },
+        "DateAirport": {
+            "type": "object",
+            "properties": {
+                "date": {
+                    "type": "string",
+                    "format": "date",
+                    "description": "Date of flight (airport local date).",
+                    "example": "2019-01-01"
+                },
+                "airportCode": {
+                    "type": "string",
+                    "minLength": 3,
+                    "maxLength": 3,
+                    "pattern": "^[A-Z]{3}$",
+                    "description": "International Air Transport Association airport code.",
+                    "example": "SFO"
+                },
+                "countryCode": {
+                    "$ref": "#/domains/Generic/types/CountryCode",
+                    "description": "Country code of airport.",
+                    "example": "us"
+                }
+            },
+            "required": [
+                "date",
+                "airportCode"
+            ],
+            "additionalProperties": false
         },
         "DatePlace": {
             "type": "object",

--- a/src/schema/flight-booking.json
+++ b/src/schema/flight-booking.json
@@ -22,10 +22,6 @@
         "selectedInboundFlight": {
             "typeRef": "#/domains/FlightBooking/types/Flight"
         },
-        "itinerary": {
-            "typeRef": "#/domains/FlightBooking/types/Itinerary",
-            "initial": true
-        },
         "account": {
             "typeRef": "#/domains/Generic/types/Account",
             "initial": true
@@ -98,29 +94,6 @@
                     "default": false
                 }
             }
-        },
-        "Itinerary": {
-            "type": "object",
-            "description": "Information about flights and cabin class preference.",
-            "properties": {
-                "cabinClass": {
-                    "$ref": "#/domains/FlightBooking/types/CabinClass",
-                    "description": "Preferred cabin class, used on flight search forms."
-                },
-                "outbound": {
-                    "$ref": "#/domains/FlightBooking/types/Flight",
-                    "description": "Outbound flight specification."
-                },
-                "inbound": {
-                    "$ref": "#/domains/FlightBooking/types/Flight",
-                    "description": "Inbound (return) flight specification. If omitted, one-way flight booking flow is used."
-                }
-            },
-            "required": [
-                "cabinClass",
-                "outbound"
-            ],
-            "additionalProperties": false
         },
         "Search": {
             "type": "object",

--- a/src/schema/flight-booking.json
+++ b/src/schema/flight-booking.json
@@ -141,8 +141,8 @@
             "type": "object",
             "description": "Outbound and inbound flights specification.",
             "properties": {
-                "origin": { "$ref": "#/domains/FlightBooking/types/DatePlace" },
-                "destination": { "$ref": "#/domains/FlightBooking/types/DatePlace" }
+                "origin": { "$ref": "#/domains/FlightBooking/types/DateTimeAirport" },
+                "destination": { "$ref": "#/domains/FlightBooking/types/DateTimeAirport" }
             },
             "required": [
                 "origin",
@@ -183,7 +183,7 @@
             ],
             "additionalProperties": false
         },
-        "DatePlace": {
+        "DateTimeAirport": {
             "type": "object",
             "properties": {
                 "dateTime": {

--- a/src/schema/generic.json
+++ b/src/schema/generic.json
@@ -4,6 +4,16 @@
     "inputs": {},
     "outputs": {},
     "types": {
+        "Ages": {
+            "type": "array",
+            "description": "A list of ages of persons.",
+            "items": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 200,
+                "example": 42
+            }
+        },
         "URL": {
             "type": "string",
             "format": "url",

--- a/src/schema/vacation-rental.json
+++ b/src/schema/vacation-rental.json
@@ -8,7 +8,8 @@
             "initial": true
         },
         "guestAges": {
-            "typeRef": "#/domains/VacationRental/types/GuestAges",
+            "typeRef": "#/domains/Generic/types/Ages",
+            "description": "Ages of all guests.",
             "initial": true
         },
         "account": {
@@ -85,15 +86,6 @@
                 "name",
                 "price"
             ]
-        },
-        "GuestAges": {
-            "type": "array",
-            "items": {
-                "type": "number",
-                "minimum": 0,
-                "maximum": 200,
-                "example": 42
-            }
         },
         "Pets": {
             "type": "object",

--- a/test/flight-booking.test.js
+++ b/test/flight-booking.test.js
@@ -10,53 +10,55 @@ describe('FlightBooking', () => {
     describe('Itinerary', () => {
 
         it('should accept valid flight', async () => {
-            const { valid, errors } = await FlightBooking.validate('Itinerary', {
+            const { valid, errors } = await FlightBooking.validate('Search', {
                 cabinClass: 'economy',
                 outbound: {
                     origin: {
                         countryCode: 'us',
-                        dateTime: '2017-10-20 00:55',
+                        date: '2017-10-20',
                         airportCode: 'SFO',
                     },
                     destination: {
                         countryCode: 'us',
-                        dateTime: '2017-10-20 17:14',
+                        date: '2017-10-20',
                         airportCode: 'LGA',
                     },
                 },
                 inbound: {
                     origin: {
                         countryCode: 'us',
-                        dateTime: '2017-11-24 17:59',
+                        date: '2017-11-24',
                         airportCode: 'LGA',
                     },
                     destination: {
                         countryCode: 'us',
-                        dateTime: '2017-11-25 10:59',
+                        date: '2017-11-25',
                         airportCode: 'SFO',
                     },
                 },
+                passengerAges: [31, 32, 9],
             });
             expect(valid).toEqual(true);
             expect(errors.length).toEqual(0);
         });
 
         it('should not accept invalid inbound flight', async () => {
-            const { valid, errors } = await FlightBooking.validate('Itinerary', {
+            const { valid, errors } = await FlightBooking.validate('Search', {
                 cabinClass: 'economy',
                 outbound: {
                     origin: {
                         countryCode: 'us',
-                        dateTime: '2017-10-20 00:55',
+                        date: '2017-10-20',
                         airportCode: 'SFO',
                     },
                     destination: {
                         countryCode: 'us',
-                        dateTime: '2017-10-20 17:14',
+                        date: '2017-10-20',
                         airportCode: 'LGA',
                     },
                 },
                 inbound: 'smth',
+                passengerAges: [31, 32, 9],
             });
             expect(valid).toEqual(false);
             expect(errors.length).toBeGreaterThan(0);
@@ -64,32 +66,34 @@ describe('FlightBooking', () => {
         });
 
         it('should not require inbound flight', async () => {
-            const { valid, errors } = await FlightBooking.validate('Itinerary', {
+            const { valid, errors } = await FlightBooking.validate('Search', {
                 cabinClass: 'economy',
                 outbound: {
                     origin: {
                         countryCode: 'us',
-                        dateTime: '2017-10-20 00:55',
+                        date: '2017-10-20',
                         airportCode: 'SFO',
                     },
                     destination: {
                         countryCode: 'us',
-                        dateTime: '2017-10-20 17:14',
+                        date: '2017-10-20',
                         airportCode: 'LGA',
                     },
                 },
+                passengerAges: [31, 32, 9],
             });
             expect(valid).toEqual(true);
             expect(errors.length).toEqual(0);
         });
 
         it('should not allow incorrect destination/origin', async () => {
-            const { valid, errors } = await FlightBooking.validate('Itinerary', {
+            const { valid, errors } = await FlightBooking.validate('Search', {
                 cabinClass: 'economy',
                 outbound: {
                     origin: {},
                     destination: {},
                 },
+                passengerAges: [31, 32, 9],
             });
             expect(valid).toEqual(false);
             expect(errors.length).toBeGreaterThan(0);


### PR DESCRIPTION
This PR adds `/search`, `/selectedOutboundFlight` and `/selectedInboundFlight` and removes `/itinerary`.

There is currently no `outboundFlights` or `inboundFlights` output, as we do not have the tools to output these and significant development would be require to get these. Off the top of my head:

- date parser with dates and times in different keys
- `airport name` (English or LocalLanguage) to `airport code + country code` translation
- various JSON tools only available in UDF