### PR TITLE
Allow browser-fetch resolution in both webpack and browserify.

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "src/"
   ],
   "browser": {
-    "./src/fetch.js": "src/fetch-browser.js"
+    "node-fetch": "./src/fetch-browser.js"
   },
   "scripts": {
     "check": "eslint --ext=js,vue .",

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -1,1 +1,0 @@
-module.exports = require('node-fetch');

--- a/src/provider.js
+++ b/src/provider.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Protocol = require('./protocol');
-const fetch = require('./fetch');
+const fetch = require('node-fetch');
 
 const DEFAULT_OPTIONS = {
     url: 'https://protocol.automationcloud.net/schema.json',


### PR DESCRIPTION
The relative path on the left hand side of the resolution was causing a failure in webpack. This avoids it, and adjusts the right hand side to work for both too.