### PR TITLE
Outlines new attributes required to unblock Guided Docs

### DIFF
--- a/schema/broadband-signup.json
+++ b/schema/broadband-signup.json
@@ -508,5 +508,13 @@
         }
     ],
     "attributes": {
+        "staticData": {
+            "type": "object",
+            "description": "Static input data for QA jobs"
+        },
+        "generatorInput": {
+            "type": "object",
+            "description": "Job Input Bundler config"
+        }
     }
 }

--- a/schema/broadband-signup.json
+++ b/schema/broadband-signup.json
@@ -507,18 +507,5 @@
             "description": "The user being signed up is already a customer of this service."
         }
     ],
-    "attributes": {
-        "staticData": {
-            "type": "object",
-            "description": "Static input data for QA jobs"
-        },
-        "generatorInput": {
-            "type": "object",
-            "description": "Job Input Bundler config"
-        },
-        "showInGuidedDocs": {
-            "type": "boolean",
-            "default": false
-        }
-    }
+    "attributes": {}
 }

--- a/schema/broadband-signup.json
+++ b/schema/broadband-signup.json
@@ -515,5 +515,18 @@
             "description": "The user being signed up is already a customer of this service."
         }
     ],
-    "attributes": {}
+    "attributes": {
+        "staticData": {
+            "type": "object",
+            "description": "Static input data for QA jobs"
+        },
+        "generatorInput": {
+            "type": "object",
+            "description": "Job Input Bundler config"
+        },
+        "showInGuidedDocs": {
+            "type": "boolean",
+            "default": false
+        }
+    }
 }

--- a/schema/broadband-signup.json
+++ b/schema/broadband-signup.json
@@ -515,6 +515,10 @@
         "generatorInput": {
             "type": "object",
             "description": "Job Input Bundler config"
+        },
+        "showInGuidedDocs": {
+            "type": "boolean",
+            "default": false
         }
     }
 }

--- a/schema/coach-booking.json
+++ b/schema/coach-booking.json
@@ -343,5 +343,19 @@
         }
     ],
     "attributes": {
+        "staticData": {
+            "type": "object",
+            "description": "Static input data for QA jobs",
+            "example": {
+                "url": "https://playground.automationcloud.net"
+            }
+        },
+        "generatorInput": {
+            "type": "object",
+            "description": "Job Input Bundler config",
+            "example": {
+                "extractionServiceId": "e44a4f1b-aa5c-4b36-8db3-a7c78c404b90"
+            }
+        }
     }
 }

--- a/schema/coach-booking.json
+++ b/schema/coach-booking.json
@@ -356,6 +356,10 @@
             "example": {
                 "extractionServiceId": "e44a4f1b-aa5c-4b36-8db3-a7c78c404b90"
             }
+        },
+        "showInGuidedDocs": {
+            "type": "boolean",
+            "default": false
         }
     }
 }

--- a/schema/coach-booking.json
+++ b/schema/coach-booking.json
@@ -345,17 +345,11 @@
     "attributes": {
         "staticData": {
             "type": "object",
-            "description": "Static input data for QA jobs",
-            "example": {
-                "url": "https://playground.automationcloud.net"
-            }
+            "description": "Static input data for QA jobs"
         },
         "generatorInput": {
             "type": "object",
-            "description": "Job Input Bundler config",
-            "example": {
-                "extractionServiceId": "e44a4f1b-aa5c-4b36-8db3-a7c78c404b90"
-            }
+            "description": "Job Input Bundler config"
         },
         "showInGuidedDocs": {
             "type": "boolean",

--- a/schema/coach-booking.json
+++ b/schema/coach-booking.json
@@ -342,18 +342,5 @@
             "description": "The website claims that either no seats are available, or the selected seats are not available."
         }
     ],
-    "attributes": {
-        "staticData": {
-            "type": "object",
-            "description": "Static input data for QA jobs"
-        },
-        "generatorInput": {
-            "type": "object",
-            "description": "Job Input Bundler config"
-        },
-        "showInGuidedDocs": {
-            "type": "boolean",
-            "default": false
-        }
-    }
+    "attributes": {}
 }

--- a/schema/coach-booking.json
+++ b/schema/coach-booking.json
@@ -345,5 +345,18 @@
             "description": "The website claims that either no seats are available, or the selected seats are not available."
         }
     ],
-    "attributes": {}
+    "attributes": {
+        "staticData": {
+            "type": "object",
+            "description": "Static input data for QA jobs"
+        },
+        "generatorInput": {
+            "type": "object",
+            "description": "Job Input Bundler config"
+        },
+        "showInGuidedDocs": {
+            "type": "boolean",
+            "default": false
+        }
+    }
 }

--- a/schema/event-booking.json
+++ b/schema/event-booking.json
@@ -230,6 +230,10 @@
             "example": {
                 "extractionServiceId": "e44a4f1b-aa5c-4b36-8db3-a7c78c404b90"
             }
+        },
+        "showInGuidedDocs": {
+            "type": "boolean",
+            "default": false
         }
     }
 }

--- a/schema/event-booking.json
+++ b/schema/event-booking.json
@@ -219,17 +219,11 @@
     "attributes": {
         "staticData": {
             "type": "object",
-            "description": "Static input data for QA jobs",
-            "example": {
-                "url": "https://playground.automationcloud.net"
-            }
+            "description": "Static input data for QA jobs"
         },
         "generatorInput": {
             "type": "object",
-            "description": "Job Input Bundler config",
-            "example": {
-                "extractionServiceId": "e44a4f1b-aa5c-4b36-8db3-a7c78c404b90"
-            }
+            "description": "Job Input Bundler config"
         },
         "showInGuidedDocs": {
             "type": "boolean",

--- a/schema/event-booking.json
+++ b/schema/event-booking.json
@@ -216,18 +216,5 @@
             "description": "Requested event is not found"
         }
     ],
-    "attributes": {
-        "staticData": {
-            "type": "object",
-            "description": "Static input data for QA jobs"
-        },
-        "generatorInput": {
-            "type": "object",
-            "description": "Job Input Bundler config"
-        },
-        "showInGuidedDocs": {
-            "type": "boolean",
-            "default": false
-        }
-    }
+    "attributes": {}
 }

--- a/schema/event-booking.json
+++ b/schema/event-booking.json
@@ -220,5 +220,18 @@
             "description": "Requested event is not found"
         }
     ],
-    "attributes": {}
+    "attributes": {
+        "staticData": {
+            "type": "object",
+            "description": "Static input data for QA jobs"
+        },
+        "generatorInput": {
+            "type": "object",
+            "description": "Job Input Bundler config"
+        },
+        "showInGuidedDocs": {
+            "type": "boolean",
+            "default": false
+        }
+    }
 }

--- a/schema/event-booking.json
+++ b/schema/event-booking.json
@@ -216,5 +216,20 @@
             "description": "Requested event is not found"
         }
     ],
-    "attributes": {}
+    "attributes": {
+        "staticData": {
+            "type": "object",
+            "description": "Static input data for QA jobs",
+            "example": {
+                "url": "https://playground.automationcloud.net"
+            }
+        },
+        "generatorInput": {
+            "type": "object",
+            "description": "Job Input Bundler config",
+            "example": {
+                "extractionServiceId": "e44a4f1b-aa5c-4b36-8db3-a7c78c404b90"
+            }
+        }
+    }
 }

--- a/schema/flight-booking.json
+++ b/schema/flight-booking.json
@@ -609,55 +609,15 @@
         },
         "staticData": {
             "type": "object",
-            "description": "Input mocks for QA perposes",
+            "description": "Static input data for QA jobs",
             "example": {
-                "url": "https://playground.automationcloud.net",
-                "search": {
-                    "cabinClass": "economy",
-                    "passengerAges": [
-                        39
-                    ],
-                    "outbound": {
-                        "origin": {
-                            "date": "2018-11-22",
-                            "airportCode": "JFK",
-                            "countryCode": "us"
-                        },
-                        "destination": {
-                            "date": "2018-11-22",
-                            "airportCode": "LHR",
-                            "countryCode": "gb"
-                        }
-                    },
-                    "inbound": {
-                        "origin": {
-                            "date": "2018-12-24",
-                            "airportCode": "LHR",
-                            "countryCode": "gb"
-                        },
-                        "destination": {
-                            "date": "2018-12-24",
-                            "airportCode": "JFK",
-                            "countryCode": "us"
-                        }
-                    }
-                }
+                "url": "https://playground.automationcloud.net"
             }
         },
         "generatorInput": {
             "type": "object",
-            "description": "Input generator configuration",
+            "description": "Job Input Bundler config",
             "example": {
-                "inboundMonthYear": 10,
-                "outboundMonthYear": 20,
-                "passengers": {
-                    "items": [
-                        {
-                            "dateOfBirth": { "age": 33 },
-                            "document": { "number": "123" }
-                        }
-                    ]
-                },
                 "extractionServiceId": "e44a4f1b-aa5c-4b36-8db3-a7c78c404b90"
             }
         }

--- a/schema/flight-booking.json
+++ b/schema/flight-booking.json
@@ -610,6 +610,18 @@
             "minLength": 2,
             "maxLength": 4,
             "example": "AA"
+        },
+        "staticData": {
+            "type": "object",
+            "description": "Static input data for QA jobs"
+        },
+        "generatorInput": {
+            "type": "object",
+            "description": "Job Input Bundler config"
+        },
+        "showInGuidedDocs": {
+            "type": "boolean",
+            "default": false
         }
     }
 }

--- a/schema/flight-booking.json
+++ b/schema/flight-booking.json
@@ -620,6 +620,10 @@
             "example": {
                 "extractionServiceId": "e44a4f1b-aa5c-4b36-8db3-a7c78c404b90"
             }
+        },
+        "showInGuidedDocs": {
+            "type": "boolean",
+            "default": false
         }
     }
 }

--- a/schema/flight-booking.json
+++ b/schema/flight-booking.json
@@ -606,6 +606,60 @@
             "minLength": 2,
             "maxLength": 4,
             "example": "AA"
+        },
+        "staticData": {
+            "type": "object",
+            "description": "Input mocks for QA perposes",
+            "example": {
+                "url": "https://playground.automationcloud.net",
+                "search": {
+                    "cabinClass": "economy",
+                    "passengerAges": [
+                        39
+                    ],
+                    "outbound": {
+                        "origin": {
+                            "date": "2018-11-22",
+                            "airportCode": "JFK",
+                            "countryCode": "us"
+                        },
+                        "destination": {
+                            "date": "2018-11-22",
+                            "airportCode": "LHR",
+                            "countryCode": "gb"
+                        }
+                    },
+                    "inbound": {
+                        "origin": {
+                            "date": "2018-12-24",
+                            "airportCode": "LHR",
+                            "countryCode": "gb"
+                        },
+                        "destination": {
+                            "date": "2018-12-24",
+                            "airportCode": "JFK",
+                            "countryCode": "us"
+                        }
+                    }
+                }
+            }
+        },
+        "generatorInput": {
+            "type": "object",
+            "description": "Input generator configuration",
+            "example": {
+                "inboundMonthYear": 10,
+                "outboundMonthYear": 20,
+                "passengers": {
+                    "items": [
+                        {
+                            "dateOfBirth": { "age": 33 },
+                            "document": { "number": "123" }
+                        }
+                    ]
+                },
+                "extractionServiceId": "e44a4f1b-aa5c-4b36-8db3-a7c78c404b90"
+            }
         }
     }
 }

--- a/schema/flight-booking.json
+++ b/schema/flight-booking.json
@@ -606,24 +606,6 @@
             "minLength": 2,
             "maxLength": 4,
             "example": "AA"
-        },
-        "staticData": {
-            "type": "object",
-            "description": "Static input data for QA jobs",
-            "example": {
-                "url": "https://playground.automationcloud.net"
-            }
-        },
-        "generatorInput": {
-            "type": "object",
-            "description": "Job Input Bundler config",
-            "example": {
-                "extractionServiceId": "e44a4f1b-aa5c-4b36-8db3-a7c78c404b90"
-            }
-        },
-        "showInGuidedDocs": {
-            "type": "boolean",
-            "default": false
         }
     }
 }

--- a/schema/holiday-booking.json
+++ b/schema/holiday-booking.json
@@ -283,17 +283,11 @@
     "attributes": {
         "staticData": {
             "type": "object",
-            "description": "Static input data for QA jobs",
-            "example": {
-                "url": "https://playground.automationcloud.net"
-            }
+            "description": "Static input data for QA jobs"
         },
         "generatorInput": {
             "type": "object",
-            "description": "Job Input Bundler config",
-            "example": {
-                "extractionServiceId": "e44a4f1b-aa5c-4b36-8db3-a7c78c404b90"
-            }
+            "description": "Job Input Bundler config"
         },
         "showInGuidedDocs": {
             "type": "boolean",

--- a/schema/holiday-booking.json
+++ b/schema/holiday-booking.json
@@ -280,18 +280,5 @@
     },
     "errors": [
     ],
-    "attributes": {
-        "staticData": {
-            "type": "object",
-            "description": "Static input data for QA jobs"
-        },
-        "generatorInput": {
-            "type": "object",
-            "description": "Job Input Bundler config"
-        },
-        "showInGuidedDocs": {
-            "type": "boolean",
-            "default": false
-        }
-    }
+    "attributes": {}
 }

--- a/schema/holiday-booking.json
+++ b/schema/holiday-booking.json
@@ -294,6 +294,10 @@
             "example": {
                 "extractionServiceId": "e44a4f1b-aa5c-4b36-8db3-a7c78c404b90"
             }
+        },
+        "showInGuidedDocs": {
+            "type": "boolean",
+            "default": false
         }
     }
 }

--- a/schema/holiday-booking.json
+++ b/schema/holiday-booking.json
@@ -310,5 +310,18 @@
     },
     "errors": [
     ],
-    "attributes": {}
+    "attributes": {
+        "staticData": {
+            "type": "object",
+            "description": "Static input data for QA jobs"
+        },
+        "generatorInput": {
+            "type": "object",
+            "description": "Job Input Bundler config"
+        },
+        "showInGuidedDocs": {
+            "type": "boolean",
+            "default": false
+        }
+    }
 }

--- a/schema/holiday-booking.json
+++ b/schema/holiday-booking.json
@@ -281,5 +281,19 @@
     "errors": [
     ],
     "attributes": {
+        "staticData": {
+            "type": "object",
+            "description": "Static input data for QA jobs",
+            "example": {
+                "url": "https://playground.automationcloud.net"
+            }
+        },
+        "generatorInput": {
+            "type": "object",
+            "description": "Job Input Bundler config",
+            "example": {
+                "extractionServiceId": "e44a4f1b-aa5c-4b36-8db3-a7c78c404b90"
+            }
+        }
     }
 }

--- a/schema/hotel-booking.json
+++ b/schema/hotel-booking.json
@@ -318,17 +318,11 @@
     "attributes": {
         "staticData": {
             "type": "object",
-            "description": "Static input data for QA jobs",
-            "example": {
-                "url": "https://playground.automationcloud.net"
-            }
+            "description": "Static input data for QA jobs"
         },
         "generatorInput": {
             "type": "object",
-            "description": "Job Input Bundler config",
-            "example": {
-                "extractionServiceId": "e44a4f1b-aa5c-4b36-8db3-a7c78c404b90"
-            }
+            "description": "Job Input Bundler config"
         },
         "showInGuidedDocs": {
             "type": "boolean",

--- a/schema/hotel-booking.json
+++ b/schema/hotel-booking.json
@@ -329,6 +329,10 @@
             "example": {
                 "extractionServiceId": "e44a4f1b-aa5c-4b36-8db3-a7c78c404b90"
             }
+        },
+        "showInGuidedDocs": {
+            "type": "boolean",
+            "default": false
         }
     }
 }

--- a/schema/hotel-booking.json
+++ b/schema/hotel-booking.json
@@ -318,5 +318,18 @@
             "description": "The website claims the room is not available for the selected dates."
         }
     ],
-    "attributes": {}
+    "attributes": {
+        "staticData": {
+            "type": "object",
+            "description": "Static input data for QA jobs"
+        },
+        "generatorInput": {
+            "type": "object",
+            "description": "Job Input Bundler config"
+        },
+        "showInGuidedDocs": {
+            "type": "boolean",
+            "default": false
+        }
+    }
 }

--- a/schema/hotel-booking.json
+++ b/schema/hotel-booking.json
@@ -315,18 +315,5 @@
             "description": "The website claims the room is not available for the selected dates."
         }
     ],
-    "attributes": {
-        "staticData": {
-            "type": "object",
-            "description": "Static input data for QA jobs"
-        },
-        "generatorInput": {
-            "type": "object",
-            "description": "Job Input Bundler config"
-        },
-        "showInGuidedDocs": {
-            "type": "boolean",
-            "default": false
-        }
-    }
+    "attributes": {}
 }

--- a/schema/hotel-booking.json
+++ b/schema/hotel-booking.json
@@ -316,5 +316,19 @@
         }
     ],
     "attributes": {
+        "staticData": {
+            "type": "object",
+            "description": "Static input data for QA jobs",
+            "example": {
+                "url": "https://playground.automationcloud.net"
+            }
+        },
+        "generatorInput": {
+            "type": "object",
+            "description": "Job Input Bundler config",
+            "example": {
+                "extractionServiceId": "e44a4f1b-aa5c-4b36-8db3-a7c78c404b90"
+            }
+        }
     }
 }

--- a/schema/loan-application.json
+++ b/schema/loan-application.json
@@ -514,5 +514,18 @@
             "description":"Loan application denied by lender"
         }
     ],
-    "attributes": {}
+    "attributes": {
+        "staticData": {
+            "type": "object",
+            "description": "Static input data for QA jobs"
+        },
+        "generatorInput": {
+            "type": "object",
+            "description": "Job Input Bundler config"
+        },
+        "showInGuidedDocs": {
+            "type": "boolean",
+            "default": false
+        }
+    }
 }

--- a/schema/loan-application.json
+++ b/schema/loan-application.json
@@ -513,18 +513,5 @@
             "description":"Loan application denied by lender"
         }
     ],
-    "attributes": {
-        "staticData": {
-            "type": "object",
-            "description": "Static input data for QA jobs"
-        },
-        "generatorInput": {
-            "type": "object",
-            "description": "Job Input Bundler config"
-        },
-        "showInGuidedDocs": {
-            "type": "boolean",
-            "default": false
-        }
-    }
+    "attributes": {}
 }

--- a/schema/loan-application.json
+++ b/schema/loan-application.json
@@ -516,17 +516,11 @@
     "attributes": {
         "staticData": {
             "type": "object",
-            "description": "Static input data for QA jobs",
-            "example": {
-                "url": "https://playground.automationcloud.net"
-            }
+            "description": "Static input data for QA jobs"
         },
         "generatorInput": {
             "type": "object",
-            "description": "Job Input Bundler config",
-            "example": {
-                "extractionServiceId": "e44a4f1b-aa5c-4b36-8db3-a7c78c404b90"
-            }
+            "description": "Job Input Bundler config"
         },
         "showInGuidedDocs": {
             "type": "boolean",

--- a/schema/loan-application.json
+++ b/schema/loan-application.json
@@ -527,6 +527,10 @@
             "example": {
                 "extractionServiceId": "e44a4f1b-aa5c-4b36-8db3-a7c78c404b90"
             }
+        },
+        "showInGuidedDocs": {
+            "type": "boolean",
+            "default": false
         }
     }
 }

--- a/schema/loan-application.json
+++ b/schema/loan-application.json
@@ -513,5 +513,20 @@
             "description":"Loan application denied by lender"
         }
     ],
-    "attributes": {}
+    "attributes": {
+        "staticData": {
+            "type": "object",
+            "description": "Static input data for QA jobs",
+            "example": {
+                "url": "https://playground.automationcloud.net"
+            }
+        },
+        "generatorInput": {
+            "type": "object",
+            "description": "Job Input Bundler config",
+            "example": {
+                "extractionServiceId": "e44a4f1b-aa5c-4b36-8db3-a7c78c404b90"
+            }
+        }
+    }
 }

--- a/schema/motor-insurance.json
+++ b/schema/motor-insurance.json
@@ -551,5 +551,20 @@
             "description": "Registration number is required by the website"
         }
     ],
-    "attributes": {}
+    "attributes": {
+        "staticData": {
+            "type": "object",
+            "description": "Static input data for QA jobs",
+            "example": {
+                "url": "https://playground.automationcloud.net"
+            }
+        },
+        "generatorInput": {
+            "type": "object",
+            "description": "Job Input Bundler config",
+            "example": {
+                "extractionServiceId": "e44a4f1b-aa5c-4b36-8db3-a7c78c404b90"
+            }
+        }
+    }
 }

--- a/schema/motor-insurance.json
+++ b/schema/motor-insurance.json
@@ -554,17 +554,11 @@
     "attributes": {
         "staticData": {
             "type": "object",
-            "description": "Static input data for QA jobs",
-            "example": {
-                "url": "https://playground.automationcloud.net"
-            }
+            "description": "Static input data for QA jobs"
         },
         "generatorInput": {
             "type": "object",
-            "description": "Job Input Bundler config",
-            "example": {
-                "extractionServiceId": "e44a4f1b-aa5c-4b36-8db3-a7c78c404b90"
-            }
+            "description": "Job Input Bundler config"
         },
         "showInGuidedDocs": {
             "type": "boolean",

--- a/schema/motor-insurance.json
+++ b/schema/motor-insurance.json
@@ -561,5 +561,18 @@
             "description": "Registration number is required by the website"
         }
     ],
-    "attributes": {}
+    "attributes": {
+        "staticData": {
+            "type": "object",
+            "description": "Static input data for QA jobs"
+        },
+        "generatorInput": {
+            "type": "object",
+            "description": "Job Input Bundler config"
+        },
+        "showInGuidedDocs": {
+            "type": "boolean",
+            "default": false
+        }
+    }
 }

--- a/schema/motor-insurance.json
+++ b/schema/motor-insurance.json
@@ -565,6 +565,10 @@
             "example": {
                 "extractionServiceId": "e44a4f1b-aa5c-4b36-8db3-a7c78c404b90"
             }
+        },
+        "showInGuidedDocs": {
+            "type": "boolean",
+            "default": false
         }
     }
 }

--- a/schema/motor-insurance.json
+++ b/schema/motor-insurance.json
@@ -551,18 +551,5 @@
             "description": "Registration number is required by the website"
         }
     ],
-    "attributes": {
-        "staticData": {
-            "type": "object",
-            "description": "Static input data for QA jobs"
-        },
-        "generatorInput": {
-            "type": "object",
-            "description": "Job Input Bundler config"
-        },
-        "showInGuidedDocs": {
-            "type": "boolean",
-            "default": false
-        }
-    }
+    "attributes": {}
 }

--- a/schema/vacation-rental.json
+++ b/schema/vacation-rental.json
@@ -174,5 +174,20 @@
             "example": "Vacation rental unavailable on given date provided"
         }
     ],
-    "attributes": {}
+    "attributes": {
+        "staticData": {
+            "type": "object",
+            "description": "Static input data for QA jobs",
+            "example": {
+                "url": "https://playground.automationcloud.net"
+            }
+        },
+        "generatorInput": {
+            "type": "object",
+            "description": "Job Input Bundler config",
+            "example": {
+                "extractionServiceId": "e44a4f1b-aa5c-4b36-8db3-a7c78c404b90"
+            }
+        }
+    }
 }

--- a/schema/vacation-rental.json
+++ b/schema/vacation-rental.json
@@ -176,5 +176,18 @@
             "example": "Vacation rental unavailable on given date provided"
         }
     ],
-    "attributes": {}
+    "attributes": {
+        "staticData": {
+            "type": "object",
+            "description": "Static input data for QA jobs"
+        },
+        "generatorInput": {
+            "type": "object",
+            "description": "Job Input Bundler config"
+        },
+        "showInGuidedDocs": {
+            "type": "boolean",
+            "default": false
+        }
+    }
 }

--- a/schema/vacation-rental.json
+++ b/schema/vacation-rental.json
@@ -177,17 +177,11 @@
     "attributes": {
         "staticData": {
             "type": "object",
-            "description": "Static input data for QA jobs",
-            "example": {
-                "url": "https://playground.automationcloud.net"
-            }
+            "description": "Static input data for QA jobs"
         },
         "generatorInput": {
             "type": "object",
-            "description": "Job Input Bundler config",
-            "example": {
-                "extractionServiceId": "e44a4f1b-aa5c-4b36-8db3-a7c78c404b90"
-            }
+            "description": "Job Input Bundler config"
         },
         "showInGuidedDocs": {
             "type": "boolean",

--- a/schema/vacation-rental.json
+++ b/schema/vacation-rental.json
@@ -174,18 +174,5 @@
             "example": "Vacation rental unavailable on given date provided"
         }
     ],
-    "attributes": {
-        "staticData": {
-            "type": "object",
-            "description": "Static input data for QA jobs"
-        },
-        "generatorInput": {
-            "type": "object",
-            "description": "Job Input Bundler config"
-        },
-        "showInGuidedDocs": {
-            "type": "boolean",
-            "default": false
-        }
-    }
+    "attributes": {}
 }

--- a/schema/vacation-rental.json
+++ b/schema/vacation-rental.json
@@ -188,6 +188,10 @@
             "example": {
                 "extractionServiceId": "e44a4f1b-aa5c-4b36-8db3-a7c78c404b90"
             }
+        },
+        "showInGuidedDocs": {
+            "type": "boolean",
+            "default": false
         }
     }
 }

--- a/src/meta.json
+++ b/src/meta.json
@@ -61,6 +61,20 @@
                 },
                 "attributes": {
                     "type": "object",
+                    "properties": {
+                        "staticData": {
+                            "type": "object",
+                            "description": "Static input data for QA jobs"
+                        },
+                        "generatorInput": {
+                            "type": "object",
+                            "description": "Job Input Bundler config"
+                        },
+                        "showInGuidedDocs": {
+                            "type": "boolean",
+                            "default": false
+                        }
+                    },
                     "additionalProperties": {
                         "$ref": "#/definitions/TypeDef"
                     }

--- a/src/meta.json
+++ b/src/meta.json
@@ -61,20 +61,6 @@
                 },
                 "attributes": {
                     "type": "object",
-                    "properties": {
-                        "staticData": {
-                            "type": "object",
-                            "description": "Static input data for QA jobs"
-                        },
-                        "generatorInput": {
-                            "type": "object",
-                            "description": "Job Input Bundler config"
-                        },
-                        "showInGuidedDocs": {
-                            "type": "boolean",
-                            "default": false
-                        }
-                    },
                     "additionalProperties": {
                         "$ref": "#/definitions/TypeDef"
                     }


### PR DESCRIPTION
This PR adds attributes required to run a test job as part of the Dashboard (Guided Docs)

1) Job Input Bundler `staticData` – Static input data for QA jobs
2) Job Input Bundler `generatorInput` - Job Input Bundler config (minimum requirement atm is to have `extractionServiceId` in order to create dynamic part of initial input data, such as `search`, e.t.c. 
3) `showInGuidedDocs` (better name welcome!) – adds control over what's available in the Dashboard (Guided Docs) as this is public and we would like to be on the safe side 