### PR TITLE
[prototype] Define Canonical fields

### DIFF
--- a/schema/broadband-signup.json
+++ b/schema/broadband-signup.json
@@ -13,7 +13,8 @@
             "typeRef": "#/domains/BroadbandSignup/types/LandlineCheck"
         },
         "property": {
-            "typeRef": "#/domains/BroadbandSignup/types/Property"
+            "typeRef": "#/domains/BroadbandSignup/types/Property",
+            "canonical": true
         },
         "selectedTvPackages": {
             "typeRef": "#/domains/BroadbandSignup/types/SelectedPackages",
@@ -651,5 +652,10 @@
         }
     ],
     "attributes": {
+        "canonicalGroupingPeriod": {
+            "type": "number",
+            "description": "Canonical grouping period in minute",
+            "value": 1440
+        }
     }
 }

--- a/schema/coach-booking.json
+++ b/schema/coach-booking.json
@@ -19,7 +19,8 @@
             "sourceOutputKey": "availableInboundTrips"
         },
         "account": {
-            "typeRef": "#/domains/Generic/types/Account"
+            "typeRef": "#/domains/Generic/types/Account",
+            "canonical": true
         },
         "passengers": {
             "typeRef": "#/domains/CoachBooking/types/Passengers"
@@ -343,5 +344,10 @@
         }
     ],
     "attributes": {
+        "canonicalGroupingPeriod": {
+            "type": "number",
+            "description": "Canonical grouping period in minute",
+            "value": 1440
+        }
     }
 }

--- a/schema/event-booking.json
+++ b/schema/event-booking.json
@@ -8,7 +8,8 @@
             "initial": true
         },
         "account": {
-            "typeRef": "#/domains/Generic/types/Account"
+            "typeRef": "#/domains/Generic/types/Account",
+            "canonical": true
         },
         "accountPassword": {
             "typeRef": "#/domains/EventBooking/types/AccountPassword"
@@ -258,5 +259,11 @@
             "description": "Requested event is not found"
         }
     ],
-    "attributes": {}
+    "attributes": {
+        "canonicalGroupingPeriod": {
+            "type": "number",
+            "description": "Canonical grouping period in minute",
+            "value": 1440
+        }
+    }
 }

--- a/schema/flight-booking.json
+++ b/schema/flight-booking.json
@@ -34,7 +34,8 @@
             "typeRef": "#/domains/Generic/types/Account"
         },
         "passengers": {
-            "typeRef": "#/domains/FlightBooking/types/Passengers"
+            "typeRef": "#/domains/FlightBooking/types/Passengers",
+            "canonical": true
         },
         "payment": {
             "typeRef": "#/domains/Generic/types/Payment"
@@ -280,6 +281,7 @@
         "Passenger": {
             "type": "object",
             "pii": true,
+            "canonicalFields": ["title", "firstName", "lastName"],
             "properties": {
                 "title": {
                     "type": "string",
@@ -611,6 +613,11 @@
             "minLength": 2,
             "maxLength": 4,
             "example": "AA"
+        },
+        "canonicalGroupingPeriod": {
+            "type": "number",
+            "description": "Canonical grouping period in minute",
+            "value": 1440
         }
     }
 }

--- a/schema/generic.json
+++ b/schema/generic.json
@@ -80,6 +80,7 @@
             "type": "object",
             "description": "Account information for filling in contact details.<br/>Receipts and booking references will typically be sent to specified <code>email</code>.<br/>Some websites also require registering user account, in which case <code>password</code> must be provided.",
             "pii": true,
+            "canonicalFields": ["email", "phone"],
             "properties": {
                 "email": {
                     "type": "string",

--- a/schema/hotel-booking.json
+++ b/schema/hotel-booking.json
@@ -38,7 +38,8 @@
         },
         "mainGuest": {
             "typeRef": "#/domains/HotelBooking/types/MainGuest",
-            "description": "Personal details about the main guest."
+            "description": "Personal details about the main guest.",
+            "canonical": true
         },
         "guests": {
             "typeRef": "#/domains/HotelBooking/types/Guests",
@@ -485,5 +486,10 @@
         }
     ],
     "attributes": {
+        "canonicalGroupingPeriod": {
+            "type": "number",
+            "description": "Canonical grouping period in minute",
+            "value": 1440
+        }
     }
 }

--- a/schema/motor-insurance.json
+++ b/schema/motor-insurance.json
@@ -9,7 +9,8 @@
             "initial": true
         },
         "quote": {
-            "typeRef": "#/domains/MotorInsurance/types/Quote"
+            "typeRef": "#/domains/MotorInsurance/types/Quote",
+            "canonical": true
         },
         "account": {
             "typeRef": "#/domains/MotorInsurance/types/NullableAccount"
@@ -271,6 +272,7 @@
         "Quote": {
             "type": "object",
             "description": "Existing quote retrieval information.",
+            "canonicalFields": ["reference"],
             "properties": {
                 "reference": {
                     "type": "string",
@@ -675,5 +677,11 @@
             "description": "Registration number is required by the website"
         }
     ],
-    "attributes": {}
+    "attributes": {
+        "canonicalGroupingPeriod": {
+            "type": "number",
+            "description": "Canonical grouping period in minute",
+            "value": 1440
+        }
+    }
 }

--- a/schema/vacation-rental.json
+++ b/schema/vacation-rental.json
@@ -12,7 +12,8 @@
             "description": "Ages of all guests."
         },
         "account": {
-            "typeRef": "#/domains/Generic/types/Account"
+            "typeRef": "#/domains/Generic/types/Account",
+            "canonical": true
         },
         "payment": {
             "typeRef": "#/domains/Generic/types/Payment"
@@ -177,5 +178,11 @@
             "example": "Vacation rental unavailable on given date provided"
         }
     ],
-    "attributes": {}
+    "attributes": {
+        "canonicalGroupingPeriod": {
+            "type": "number",
+            "description": "Canonical grouping period in minute",
+            "value": 1440
+        }
+    }
 }

--- a/src/canonical-fields.js
+++ b/src/canonical-fields.js
@@ -1,0 +1,12 @@
+'use strict';
+
+module.exports = function getCanonicalFields(typeDef) {
+    if (typeDef && typeDef.spec) {
+        if (typeDef.spec.type === 'array' && typeDef.spec.items['$ref']) {
+            const childTypeDef = typeDef.domain.protocol.resolveTypeRef(typeDef.spec.items['$ref']);
+
+            return getCanonicalFields(childTypeDef);
+        }
+        return typeDef.spec.canonicalFields;
+    }
+};

--- a/src/defs.js
+++ b/src/defs.js
@@ -2,6 +2,7 @@
 
 const util = require('./util');
 const createExample = require('./example');
+const getCanonicalFields = require('./canonical-fields');
 
 class Def {
 
@@ -96,6 +97,15 @@ class CustomDef extends Def {
     isPii() {
         const typeDef = this.getTypeDef();
         return typeDef && typeDef.spec && typeDef.spec.pii || false;
+    }
+
+    isCanonical() {
+        return this.spec.canonical || false;
+    }
+
+    getCanonicalFields() {
+        const typeDef = this.getTypeDef();
+        return getCanonicalFields(typeDef) || null;
     }
 
     createExample() {

--- a/src/schema-meta.json
+++ b/src/schema-meta.json
@@ -100,6 +100,10 @@
                 "inputMethod": {
                     "type": "string",
                     "enum": [ "SeatSelection", "Consent" ]
+                },
+                "canonical": {
+                    "type": "boolean",
+                    "description": "Input determines the uniqueness of users. Only one of the Input within same domain should be marked as canonical"
                 }
             },
             "required": ["typeRef"],


### PR DESCRIPTION
In order to group the jobs created by the same user, we need to define which input key(also specific properties in input if needed) in protocol. 

This PR contains:
- which key is chosen for each domain - defined in InputDef as `canonical`
- which properties of the Input will be used if specified in TypeDef as `canonicalFields` - if not specified, use whole input object as a canonical field.
- the time period (n minutes) to limit the grouping - e.g. same user attempted purchase ticket now and failed. Then if the same user tried to purchase the ticket in defined `n minutes`, it should be grouped separately.

e.g.
in `CoachBooking` domain, we've chosen `account` input to be used as canonical.
>CoachBooking.inputs.account -> `canonical: true`

and `account` use Generic.Account type definition. and if we want to use part of the properties, we defined it in the type definition such as:
>Generic.types.Account -> `canonicalFields: ["email", "phone"]`

reference: 
[PRD](https://docs.google.com/document/d/1F7sIUJRyt3oYblcbc8lPaSoi6QCDnPo1MWljZ4cTM5s/edit#)
[canonical key research](https://docs.google.com/spreadsheets/d/1qBQcdNmR_Z5upmgFwMwXv49V1J7ItT_ymJ_SgL01Lys/edit?usp=sharing)