### PR TITLE
Canonical tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2252,21 +2252,6 @@
         "fill-range": "^2.1.0"
       }
     },
-    "expect": {
-      "version": "1.20.2",
-      "resolved": "http://registry.npmjs.org/expect/-/expect-1.20.2.tgz",
-      "integrity": "sha1-1Fj+TFYAQDa64yMkFqP2Nh8E+WU=",
-      "dev": true,
-      "requires": {
-        "define-properties": "~1.1.2",
-        "has": "^1.0.1",
-        "is-equal": "^1.5.1",
-        "is-regex": "^1.0.3",
-        "object-inspect": "^1.1.0",
-        "object-keys": "^1.0.9",
-        "tmatch": "^2.0.1"
-      }
-    },
     "express": {
       "version": "4.16.4",
       "resolved": "https://registry.npmjs.org/express/-/express-4.16.4.tgz",
@@ -3537,15 +3522,6 @@
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
-    "is-arrow-function": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/is-arrow-function/-/is-arrow-function-2.0.3.tgz",
-      "integrity": "sha1-Kb4sLY2UUIUri7r7Y1unuNjofsI=",
-      "dev": true,
-      "requires": {
-        "is-callable": "^1.0.4"
-      }
-    },
     "is-binary-path": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
@@ -3554,12 +3530,6 @@
       "requires": {
         "binary-extensions": "^1.0.0"
       }
-    },
-    "is-boolean-object": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.0.0.tgz",
-      "integrity": "sha1-mPiygDBoQhmpXzdc+9iM40Bd/5M=",
-      "dev": true
     },
     "is-buffer": {
       "version": "1.1.6",
@@ -3622,25 +3592,6 @@
       "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
       "dev": true
     },
-    "is-equal": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/is-equal/-/is-equal-1.5.5.tgz",
-      "integrity": "sha1-XoXxlX4FKIMkf+s4aWWju6Ffuz0=",
-      "dev": true,
-      "requires": {
-        "has": "^1.0.1",
-        "is-arrow-function": "^2.0.3",
-        "is-boolean-object": "^1.0.0",
-        "is-callable": "^1.1.3",
-        "is-date-object": "^1.0.1",
-        "is-generator-function": "^1.0.6",
-        "is-number-object": "^1.0.3",
-        "is-regex": "^1.0.3",
-        "is-string": "^1.0.4",
-        "is-symbol": "^1.0.1",
-        "object.entries": "^1.0.4"
-      }
-    },
     "is-equal-shallow": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
@@ -3677,12 +3628,6 @@
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
       "dev": true
     },
-    "is-generator-function": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.7.tgz",
-      "integrity": "sha512-YZc5EwyO4f2kWCax7oegfuSr9mFz1ZvieNYBEjmukLxgXfBUbxAWGVF7GZf0zidYtoBl3WvC07YK0wT76a+Rtw==",
-      "dev": true
-    },
     "is-glob": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
@@ -3700,12 +3645,6 @@
       "requires": {
         "kind-of": "^3.0.2"
       }
-    },
-    "is-number-object": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.3.tgz",
-      "integrity": "sha1-8mWrian0RQNO9q/xWo8AsA9VF5k=",
-      "dev": true
     },
     "is-plain-obj": {
       "version": "1.1.0",
@@ -3767,12 +3706,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-    },
-    "is-string": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.4.tgz",
-      "integrity": "sha1-zDqbaYV9Yh6WNyWiTK7shzuCbmQ=",
-      "dev": true
     },
     "is-svg": {
       "version": "2.1.0",
@@ -3890,6 +3823,11 @@
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
       "dev": true
+    },
+    "jsonpointer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk="
     },
     "jsx-ast-utils": {
       "version": "2.0.1",
@@ -4485,12 +4423,6 @@
         }
       }
     },
-    "object-inspect": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
-      "integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==",
-      "dev": true
-    },
     "object-keys": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
@@ -4512,18 +4444,6 @@
           "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
           "dev": true
         }
-      }
-    },
-    "object.entries": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.0.4.tgz",
-      "integrity": "sha1-G/mk3SKI9bM/Opk9JXZh8F0WGl8=",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.6.1",
-        "function-bind": "^1.1.0",
-        "has": "^1.0.1"
       }
     },
     "object.omit": {
@@ -6791,12 +6711,6 @@
       "requires": {
         "process": "~0.11.0"
       }
-    },
-    "tmatch": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/tmatch/-/tmatch-2.0.1.tgz",
-      "integrity": "sha1-DFYkbzPzDaG409colauvFmYPOM8=",
-      "dev": true
     },
     "tmp": {
       "version": "0.0.33",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "eslint": "^4.10.0",
     "eslint-config-ub": "^2.0.0",
     "eslint-plugin-vue": "^2.1.0",
-    "expect": "1",
     "mocha": "^4.0.1",
     "npm-run-all": "^4.1.2",
     "pre-commit": "^1.2.2",
@@ -50,6 +49,7 @@
   },
   "dependencies": {
     "ajv": "5.3.0",
+    "jsonpointer": "^4.0.1",
     "node-fetch": "1.7.3"
   }
 }

--- a/schema/broadband-signup.json
+++ b/schema/broadband-signup.json
@@ -18,9 +18,9 @@
         "property": {
             "typeRef": "#/domains/BroadbandSignup/types/Property",
             "canonical": [
-                "/postcode",
-                "/city",
-                "/countrySubdivision"
+                "/address/postcode",
+                "/address/city",
+                "/address/countrySubdivision"
             ]
         },
         "selectedTvPackages": {
@@ -219,7 +219,7 @@
             "pii": true,
             "properties": {
                 "postcode": {
-                    "typeRef": "#/domains/BroadbandSignup/types/Postcode"
+                    "$ref": "#/domains/BroadbandSignup/types/Postcode"
                 },
                 "landline": {
                     "type": "string",
@@ -271,7 +271,7 @@
                             "example": "Clerkenwell Close"
                         },
                         "postcode": {
-                            "typeRef": "#/domains/BroadbandSignup/types/Postcode"
+                            "$ref": "#/domains/BroadbandSignup/types/Postcode"
                         },
                         "city": {
                             "type": "string",
@@ -414,13 +414,13 @@
                     "minLength": 1
                 },
                 "description": {
-                    "typeRef": "#/domains/Generic/types/StructuredTextItem"
+                    "$ref": "#/domains/Generic/types/StructuredTextItem"
                 },
                 "price": {
-                    "typeRef": "#/domains/Generic/types/Price"
+                    "$ref": "#/domains/Generic/types/Price"
                 },
                 "image": {
-                    "typeRef": "#/domains/Generic/types/Link"
+                    "$ref": "#/domains/Generic/types/Link"
                 },
                 "estimatedSpeed": {
                     "type": "string"
@@ -574,7 +574,7 @@
                     "pii": true,
                     "properties": {
                         "postcode": {
-                            "typeRef": "#/domains/BroadbandSignup/types/Postcode"
+                            "$ref": "#/domains/BroadbandSignup/types/Postcode"
                         },
                         "landline": {
                             "type": "string",

--- a/src/defs.js
+++ b/src/defs.js
@@ -104,15 +104,6 @@ class CustomDef extends Def {
         return typeDef ? typeDef.createExample() : null;
     }
 
-    getCanonicalPointers() {
-        return this.spec.canonical || [];
-    }
-
-    getCanonicalValues(object) {
-        return this.getCanonicalPointers()
-            .map(ptr => jsonPointer.get(object, ptr));
-    }
-
 }
 
 
@@ -120,6 +111,22 @@ class InputDef extends CustomDef {
 
     constructor(domain, key) {
         super(domain, 'inputs', key);
+    }
+
+    /**
+     * @returns {Array<string> | null} array of canonical pointers or null if not defined
+     */
+    getCanonicalPointers() {
+        return this.spec.canonical || null;
+    }
+
+    /**
+     * @param {any} object input object
+     * @returns {Array<any> | null} array of canonical values or null if no canonical pointers defined
+     */
+    getCanonicalValues(object) {
+        const pointers = this.getCanonicalPointers();
+        return pointers ? pointers.map(ptr => jsonPointer.get(object, ptr)) : null;
     }
 
 }

--- a/src/defs.js
+++ b/src/defs.js
@@ -2,6 +2,7 @@
 
 const util = require('./util');
 const createExample = require('./example');
+const jsonPointer = require('jsonpointer');
 
 class Def {
 
@@ -98,13 +99,18 @@ class CustomDef extends Def {
         return typeDef && typeDef.spec && typeDef.spec.pii || false;
     }
 
-    getCanonical() {
-        return this.spec.canonical || [];
-    }
-
     createExample() {
         const typeDef = this.getTypeDef();
         return typeDef ? typeDef.createExample() : null;
+    }
+
+    getCanonicalPointers() {
+        return this.spec.canonical || [];
+    }
+
+    getCanonicalValues(object) {
+        return this.getCanonicalPointers()
+            .map(ptr => jsonPointer.get(object, ptr));
     }
 
 }

--- a/test/specs/data-generation.test.js
+++ b/test/specs/data-generation.test.js
@@ -1,6 +1,6 @@
 const Ajv = require('ajv');
 const dataGeneration = require('../../src/data-generation.json');
-const expect = require('expect');
+const assert = require('assert');
 const meta = require('../../src/data-generation-meta.json');
 const protocol = require('../protocol.js');
 
@@ -14,13 +14,13 @@ describe('Data Generation', () => {
             // eslint-disable-next-line no-console
             console.log('Validation errors:', validate.errors);
         }
-        expect(valid).toEqual(true);
+        assert.ok(valid);
     });
 
     it('references existing type definitions', () => {
-        dataGeneration.forEach(({ typeRef }) =>
-            expect(protocol.resolveTypeRef(typeRef)).toExist()
-        );
+        dataGeneration.forEach(dataGen => {
+            assert.ok(protocol.resolveTypeRef(dataGen.typeRef));
+        });
     });
 
 

--- a/test/specs/defs.test.js
+++ b/test/specs/defs.test.js
@@ -7,6 +7,11 @@ const inputDefs = protocol.getDomains()
     .map(d => d.getInputs())
     .reduce((a, b) => a.concat(b), []); // TODO replace with .flat in 2020
 
+const typeDefs = protocol.getDomains()
+    .map(d => d.getTypes())
+    .reduce((a, b) => a.concat(b), []); // TODO replace with .flat in 2020
+
+
 describe('InputDef', () => {
 
     describe('getCanonicalValues', () => {
@@ -35,6 +40,27 @@ describe('InputDef', () => {
             }
         });
 
+    });
+
+});
+
+describe('TypeDef', () => {
+
+    it('should not contain typeDef key', () => {
+        // Reason: it's easy to confuse $ref from JSON schema with our custom
+        // typeDef. Due to the way JSON Schema is designed, things like these
+        // result in validation being silently bypassed, which is never a good thing.
+        for (const typeDef of typeDefs) {
+            const keys = new Set();
+            JSON.stringify(typeDef.spec, (k, v) => {
+                keys.add(k);
+                return v;
+            });
+            assert.equal(keys.has('typeDef'), false,
+                `Type def ${typeDef.id} contains forbidden typeDef key`);
+            assert.equal(keys.has('$typeDef'), false,
+                `Type def ${typeDef.id} contains forbidden $typeDef key`);
+        }
     });
 
 });

--- a/test/specs/defs.test.js
+++ b/test/specs/defs.test.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const protocol = require('../protocol');
+const assert = require('assert');
+
+const inputDefs = protocol.getDomains()
+    .map(d => d.getInputs())
+    .reduce((a, b) => a.concat(b), []); // TODO replace with .flat in 2020
+
+describe('InputDef', () => {
+
+    describe('getCanonicalValues', () => {
+
+        it('extracts canonical values from given input object', () => {
+            for (const inputDef of inputDefs) {
+                const example = inputDef.createExample();
+                const pointers = inputDef.getCanonicalPointers();
+                if (pointers == null) {
+                    continue;
+                }
+                const values = inputDef.getCanonicalValues(example);
+                assert.ok(Array.isArray(values));
+                assert.ok(values.every(val => val != null),
+                    `Input ${inputDef.id} contains a null canonical value: ${JSON.stringify(example)}`);
+            }
+        });
+
+        it('returns null if no pointers specified', () => {
+            for (const inputDef of inputDefs) {
+                const example = inputDef.createExample();
+                const pointers = inputDef.getCanonicalPointers();
+                if (pointers == null) {
+                    assert.equal(inputDef.getCanonicalValues(example), null);
+                }
+            }
+        });
+
+    });
+
+});

--- a/test/specs/domain.test.js
+++ b/test/specs/domain.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const protocol = require('../protocol');
-const expect = require('expect');
+const assert = require('assert');
 const Internal = protocol.getDomain('Internal');
 
 describe('Domain', () => {
@@ -10,17 +10,17 @@ describe('Domain', () => {
 
         it('should resolve input definition', () => {
             const def = Internal.getDef('url');
-            expect(def).toExist();
+            assert.ok(def);
         });
 
         it('should resolve output definition', () => {
             const def = Internal.getDef('object');
-            expect(def).toExist();
+            assert.ok(def);
         });
 
         it('should resolve type definition', () => {
             const def = Internal.getDef('Value');
-            expect(def).toExist();
+            assert.ok(def);
         });
 
     });
@@ -29,13 +29,13 @@ describe('Domain', () => {
 
         it('should resolve input definition', () => {
             const def = Internal.getInputDef('url');
-            expect(def).toExist();
+            assert.ok(def);
         });
 
         it('should return null for unknown input definitions', () => {
-            expect(Internal.getInputDef('object')).toNotExist();
-            expect(Internal.getInputDef('Value')).toNotExist();
-            expect(Internal.getInputDef('nonsense')).toNotExist();
+            assert.equal(Internal.getInputDef('object'), null);
+            assert.equal(Internal.getInputDef('Value'), null);
+            assert.equal(Internal.getInputDef('nonsense'), null);
         });
 
     });
@@ -44,13 +44,13 @@ describe('Domain', () => {
 
         it('should resolve output definition', () => {
             const def = Internal.getOutputDef('object');
-            expect(def).toExist();
+            assert.ok(def);
         });
 
         it('should return null for unknown input definitions', () => {
-            expect(Internal.getOutputDef('url')).toNotExist();
-            expect(Internal.getOutputDef('Value')).toNotExist();
-            expect(Internal.getOutputDef('nonsense')).toNotExist();
+            assert.equal(Internal.getOutputDef('url'), null);
+            assert.equal(Internal.getOutputDef('Value'), null);
+            assert.equal(Internal.getOutputDef('nonsense'), null);
         });
 
     });
@@ -59,7 +59,7 @@ describe('Domain', () => {
 
         it('should resolve error lists', () => {
             const errors = Internal.getErrors();
-            expect(errors).toExist();
+            assert.ok(errors);
         });
 
     });
@@ -68,12 +68,12 @@ describe('Domain', () => {
 
         it('should resolve error', () => {
             const error = Internal.getError('InternalError');
-            expect(error).toExist();
+            assert.ok(error);
         });
 
         it('should return null for unknown error definitions', () => {
-            expect(Internal.getError('none')).toNotExist();
-            expect(Internal.getError('unknownError')).toNotExist();
+            assert.equal(Internal.getError('none'), null);
+            assert.equal(Internal.getError('unknownError'), null);
         });
 
     });
@@ -82,19 +82,20 @@ describe('Domain', () => {
 
         it('should allow valid data', async () => {
             const { valid } = await Internal.validateInput('url', 'https://github.com');
-            expect(valid).toBe(true);
+            assert.ok(valid);
         });
 
         it('should report errors for invalid data', async () => {
             const { valid, errors } = await Internal.validateInput('url', {});
-            expect(valid).toBe(false);
-            expect(errors).toBeAn(Array);
+            assert.equal(valid, false);
+            assert.ok(Array.isArray(errors));
         });
 
         it('should report error for unknown input', async () => {
             const { valid, errors } = await Internal.validateInput('Value', {});
-            expect(valid).toBe(false);
-            expect(errors.length).toEqual(1);
+            assert.equal(valid, false);
+            assert.ok(Array.isArray(errors));
+            assert.equal(errors.length, 1);
         });
 
     });
@@ -105,19 +106,20 @@ describe('Domain', () => {
             const { valid } = await Internal.validateOutput('finalPrice', {
                 price: { value: 0, currencyCode: 'usd' },
             });
-            expect(valid).toBe(true);
+            assert.ok(valid);
         });
 
         it('should report errors for invalid data', async () => {
             const { valid, errors } = await Internal.validateOutput('finalPrice', { value: 0 });
-            expect(valid).toBe(false);
-            expect(errors).toBeAn(Array);
+            assert.equal(valid, false);
+            assert.ok(Array.isArray(errors));
         });
 
         it('should report error for unknown input', async () => {
             const { valid, errors } = await Internal.validateOutput('url', 'https://github.com');
-            expect(valid).toBe(false);
-            expect(errors.length).toEqual(1);
+            assert.equal(valid, false);
+            assert.ok(Array.isArray(errors));
+            assert.equal(errors.length, 1);
         });
 
     });

--- a/test/specs/flight-booking.test.js
+++ b/test/specs/flight-booking.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const protocol = require('../protocol');
-const expect = require('expect');
+const assert = require('assert');
 
 describe('FlightBooking', () => {
 
@@ -38,8 +38,8 @@ describe('FlightBooking', () => {
                 },
                 passengerAges: [31, 32, 9],
             });
-            expect(valid).toEqual(true);
-            expect(errors.length).toEqual(0);
+            assert.ok(valid);
+            assert.equal(errors.length, 0);
         });
 
         it('should not accept invalid inbound flight', async () => {
@@ -60,9 +60,9 @@ describe('FlightBooking', () => {
                 inbound: 'smth',
                 passengerAges: [31, 32, 9],
             });
-            expect(valid).toEqual(false);
-            expect(errors.length).toBeGreaterThan(0);
-            expect(errors.find(e => e.dataPath === '/inbound')).toExist();
+            assert.equal(valid, false);
+            assert.ok(errors.length > 0);
+            assert.ok(errors.find(e => e.dataPath === '/inbound'));
         });
 
         it('should not require inbound flight', async () => {
@@ -82,8 +82,8 @@ describe('FlightBooking', () => {
                 },
                 passengerAges: [31, 32, 9],
             });
-            expect(valid).toEqual(true);
-            expect(errors.length).toEqual(0);
+            assert.ok(valid);
+            assert.equal(errors.length, 0);
         });
 
         it('should not allow incorrect destination/origin', async () => {
@@ -95,10 +95,10 @@ describe('FlightBooking', () => {
                 },
                 passengerAges: [31, 32, 9],
             });
-            expect(valid).toEqual(false);
-            expect(errors.length).toBeGreaterThan(0);
-            expect(errors.find(e => e.dataPath === '/outbound/destination')).toExist();
-            expect(errors.find(e => e.dataPath === '/outbound/origin')).toExist();
+            assert.equal(valid, false);
+            assert.ok(errors.length > 0);
+            assert.ok(errors.find(e => e.dataPath === '/outbound/destination'));
+            assert.ok(errors.find(e => e.dataPath === '/outbound/origin'));
         });
 
     });

--- a/test/specs/protocol.test.js
+++ b/test/specs/protocol.test.js
@@ -1,27 +1,26 @@
 'use strict';
 
 const protocol = require('../protocol');
-const expect = require('expect');
+const assert = require('assert');
 
 describe('Protocol', () => {
 
     it('should not contain unresolved references', () => {
         const unresolvedRefs = protocol.getUnresolvedRefs();
-        expect(unresolvedRefs.length).toEqual(0,
-            `Unresolved references are not allowed: ${unresolvedRefs}`);
+        assert.equal(unresolvedRefs.length, 0, `Unresolved references are not allowed: ${unresolvedRefs}`);
     });
 
     describe('getDomain', () => {
 
         it('should return existing domain', () => {
             const genericDomain = protocol.getDomain('Generic');
-            expect(genericDomain).toBeTruthy();
-            expect(genericDomain.id).toEqual('Generic');
+            assert.ok(genericDomain);
+            assert.equal(genericDomain.id, 'Generic');
         });
 
         it('should return null for unknown domains', () => {
             const unknown = protocol.getDomain('Unknown');
-            expect(unknown).toNotExist();
+            assert.equal(unknown, null);
         });
 
     });
@@ -30,15 +29,15 @@ describe('Protocol', () => {
 
         it('should return null if not found', () => {
             const unknown = protocol.getDef('Unknown', 'def');
-            expect(unknown).toNotExist();
+            assert.equal(unknown, null);
         });
 
         it('should contain identifier fields', () => {
             const priceDef = protocol.getDef('Generic', 'Price');
-            expect(priceDef).toExist();
-            expect(priceDef.id).toEqual('Generic.Price');
-            expect(priceDef.key).toEqual('Price');
-            expect(priceDef.ns).toEqual('types');
+            assert.ok(priceDef);
+            assert.equal(priceDef.id, 'Generic.Price');
+            assert.equal(priceDef.key, 'Price');
+            assert.equal(priceDef.ns, 'types');
         });
 
     });
@@ -47,16 +46,12 @@ describe('Protocol', () => {
 
         it('should return all errors', () => {
             const allErrors = protocol.getAllErrors();
-
             const domains = protocol.getDomains();
 
-            let errors = [];
-            domains.forEach(domain => {
-                errors = errors.concat(domain.getErrors());
-            });
-
-            expect(allErrors.length).toBe(errors.length);
-
+            const errors = domains
+                .map(d => d.getErrors())
+                .reduce((curr, arr) => curr.concat(arr), []); // TODO replace with .flat in 2020
+            assert.equal(allErrors.length, errors.length);
         });
 
     });
@@ -69,7 +64,8 @@ describe('Protocol', () => {
                     const { sourceOutputKey } = inputDef.spec;
                     if (sourceOutputKey) {
                         const output = domain.getOutputDef(sourceOutputKey);
-                        expect(output).toExist(`Cannot resource sourceOutputKey="${sourceOutputKey}" of input ${inputDef.id}`);
+                        assert.ok(output,
+                            `Cannot resolve sourceOutputKey="${sourceOutputKey}" of input ${inputDef.id}`);
                     }
                 }
             }
@@ -80,47 +76,49 @@ describe('Protocol', () => {
     describe('dataExtractionDomainId', () => {
 
         it('references existing domain', () => {
-            protocol.getDomains()
-                .filter(targetDomain => targetDomain.spec.dataExtractionDomainId)
-                .forEach(targetDomain => {
-                    const dataExtractionDomain = protocol.getDomain(targetDomain.spec.dataExtractionDomainId);
-                    expect(dataExtractionDomain).toExist(
-                        `dataExtractionDomainId property of ${targetDomain.id} domain should reference existing domain`
-                    );
-                });
+            for (const domain of protocol.getDomains()) {
+                const { dataExtractionDomainId } = domain.spec;
+                if (!dataExtractionDomainId) {
+                    continue;
+                }
+                const dataExtractionDomain = protocol.getDomain(dataExtractionDomainId);
+                assert.ok(dataExtractionDomain,
+                    `dataExtractionDomainId property of ${domain.id} domain should reference existing domain`);
+            }
         });
 
         it('requires at least one extraction output to match target input', () => {
-            protocol.getDomains()
-                .filter(targetDomain => targetDomain.spec.dataExtractionDomainId)
-                .forEach(targetDomain => {
-                    const dataExtractionDomain = protocol.getDomain(targetDomain.spec.dataExtractionDomainId);
-                    const numberOfExtractionOutputs = dataExtractionDomain.getOutputs()
-                        .filter(dataExtractionOutput => targetDomain.getInputDef(dataExtractionOutput.key))
-                        .length;
+            for (const domain of protocol.getDomains()) {
+                const { dataExtractionDomainId } = domain.spec;
+                if (!dataExtractionDomainId) {
+                    continue;
+                }
+                const dataExtractionDomain = protocol.getDomain(dataExtractionDomainId);
+                const numberOfExtractionOutputs = dataExtractionDomain.getOutputs()
+                    .filter(dataExtractionOutput => domain.getInputDef(dataExtractionOutput.key))
+                    .length;
 
-                    expect(numberOfExtractionOutputs).toBeMoreThan(0,
-                        `Data extraction domain ${dataExtractionDomain.id} should have at least one output matching target input by name`);
-                });
+                assert.ok(numberOfExtractionOutputs > 0,
+                    `Data extraction domain ${dataExtractionDomain.id} should have at least one output matching target input`);
+            }
         });
 
         it('enforces parity of typeRefs for outputs matching inputs by key', () => {
-            protocol.getDomains()
-                .filter(targetDomain => targetDomain.spec.dataExtractionDomainId)
-                .forEach(targetDomain => {
-                    const dataExtractionDomain = protocol.getDomain(targetDomain.spec.dataExtractionDomainId);
-                    dataExtractionDomain.getOutputs()
-                        .forEach(dataExtractionOutput => {
-                            const targetInput = targetDomain.getInputDef(dataExtractionOutput.key);
-                            if (targetInput) {
-                                expect(targetInput.spec.typeRef)
-                                    .toEqual(dataExtractionOutput.spec.typeRef,
-                                        `Type of ${dataExtractionDomain.id}/outputs/${dataExtractionOutput.key} do not match type of ${targetDomain.id}/inputs/${targetInput.key}`);
-                            }
-                        });
-                });
+            for (const domain of protocol.getDomains()) {
+                const { dataExtractionDomainId } = domain.spec;
+                if (!dataExtractionDomainId) {
+                    continue;
+                }
+                const dataExtractionDomain = protocol.getDomain(dataExtractionDomainId);
+                for (const extractionOutput of dataExtractionDomain.getOutputs()) {
+                    const targetInput = domain.getInputDef(extractionOutput.key);
+                    if (targetInput) {
+                        assert.equal(targetInput.spec.typeRef, extractionOutput.spec.typeRef,
+                            `Type of ${dataExtractionDomain.id}/outputs/${extractionOutput.key} does not match type of ${domain.id}/inputs/${targetInput.key}`);
+                    }
+                }
+            }
         });
-
 
     });
 

--- a/test/specs/protocol.test.js
+++ b/test/specs/protocol.test.js
@@ -50,7 +50,7 @@ describe('Protocol', () => {
 
             const errors = domains
                 .map(d => d.getErrors())
-                .reduce((curr, arr) => curr.concat(arr), []); // TODO replace with .flat in 2020
+                .reduce((a, b) => a.concat(b), []); // TODO replace with .flat in 2020
             assert.equal(allErrors.length, errors.length);
         });
 

--- a/test/specs/schema.test.js
+++ b/test/specs/schema.test.js
@@ -2,7 +2,7 @@
 
 const Ajv = require('ajv');
 const protocol = require('../protocol');
-const expect = require('expect');
+const assert = require('assert');
 const meta = require('../../src/schema-meta.json');
 
 describe('Schema', () => {
@@ -15,7 +15,7 @@ describe('Schema', () => {
             // eslint-disable-next-line no-console
             console.log('Validation errors:', validate.errors);
         }
-        expect(valid).toEqual(true);
+        assert.ok(valid);
     });
 
 });


### PR DESCRIPTION
Few things packed here:

- finally got rid of `expect` (long overdue refactor)
- changed `getCanonical` to return `null` if canonical fields not specified (to explicitly demarcate that input is not canonical and should not participate in caching)
- added `getCanonicalValues` which extracts an array of values from an input object, according to domain's meta information; made sure that values inside are not nullable
- amended some incorrect usages of `typeDef` in BroadbandSignup domain, added a regression test for that
- amended the canonical pointers for `BroadbandSignup.property` to include `/address` prefix (otherwise they don't resolve properly)
