### PR TITLE
Define initial input defaults for options

### DIFF
--- a/src/schema/broadband-signup-au.json
+++ b/src/schema/broadband-signup-au.json
@@ -13,6 +13,7 @@
         },
         "options": {
             "typeRef": "#/domains/BroadbandSignupAU/types/Options",
+            "default": {},
             "initial": true
         },
         "searchAddress": {

--- a/src/schema/broadband-signup-us.json
+++ b/src/schema/broadband-signup-us.json
@@ -13,6 +13,7 @@
         },
         "options": {
             "typeRef": "#/domains/BroadbandSignupUS/types/Options",
+            "default": {},
             "initial": true
         },
         "serviceAddress": {

--- a/src/schema/broadband-signup.json
+++ b/src/schema/broadband-signup.json
@@ -13,6 +13,7 @@
         },
         "options": {
             "typeRef": "#/domains/BroadbandSignup/types/Options",
+            "default": {},
             "initial": true
         },
         "landlineCheck": {

--- a/src/schema/contest-signup.json
+++ b/src/schema/contest-signup.json
@@ -48,6 +48,7 @@
         },
         "options": {
             "typeRef": "#/domains/ContestSignup/types/Options",
+            "default": {},
             "initial": true
         },
         "discount": {

--- a/src/schema/event-booking.json
+++ b/src/schema/event-booking.json
@@ -43,6 +43,7 @@
         },
         "options": {
             "typeRef": "#/domains/EventBooking/types/Options",
+            "default": {},
             "initial": true
         },
         "selectedRefund": {

--- a/src/schema/flight-booking-extraction.json
+++ b/src/schema/flight-booking-extraction.json
@@ -6,7 +6,9 @@
             "typeRef": "#/domains/Generic/types/URL"
         },
         "options": {
-            "typeRef": "#/domains/FlightBooking/types/Options"
+            "typeRef": "#/domains/FlightBooking/types/Options",
+            "default": {},
+            "initial": true
         },
         "selectedOriginAirportCode": {
             "typeRef": "#/domains/FlightBooking/types/AirportCode",
@@ -96,4 +98,3 @@
     "errors": [
     ]
 }
-

--- a/src/schema/holiday-booking.json
+++ b/src/schema/holiday-booking.json
@@ -13,6 +13,7 @@
         },
         "options": {
             "typeRef": "#/domains/HolidayBooking/types/Options",
+            "default": {},
             "initial": true,
             "description": "A set of options that define the automation's behaviour."
         },

--- a/src/schema/hotel-booking-extraction.json
+++ b/src/schema/hotel-booking-extraction.json
@@ -3,7 +3,9 @@
     "private": true,
     "inputs": {
         "options": {
-            "typeRef": "#/domains/HotelBookingExtraction/types/Options"
+            "typeRef": "#/domains/HotelBookingExtraction/types/Options",
+            "default": {},
+            "initial": true
         },
         "selectedDestination": {
             "typeRef": "#/domains/HotelBookingExtraction/types/Destination",
@@ -77,4 +79,3 @@
     "errors": [
     ]
 }
-

--- a/src/schema/hotel-booking.json
+++ b/src/schema/hotel-booking.json
@@ -17,6 +17,7 @@
         },
         "options": {
             "typeRef": "#/domains/HotelBooking/types/Options",
+            "default": {},
             "initial": true,
             "description": "A set of options that define the automation's behaviour."
         },

--- a/src/schema/internal.json
+++ b/src/schema/internal.json
@@ -9,7 +9,8 @@
         "options": {
             "typeRef": "#/domains/Internal/types/Options",
             "description": "Used by service-api tests.",
-            "default": {}
+            "default": {},
+            "initial": true
         },
         "url": {
             "typeRef": "#/domains/Generic/types/URL",

--- a/src/schema/motor-insurance-extraction.json
+++ b/src/schema/motor-insurance-extraction.json
@@ -3,7 +3,9 @@
     "private": true,
     "inputs": {
         "options": {
-            "typeRef": "#/domains/MotorInsurance/types/Options"
+            "typeRef": "#/domains/MotorInsurance/types/Options",
+            "default": {},
+            "initial": true
         }
     },
     "outputs": {
@@ -19,4 +21,3 @@
     "errors": [
     ]
 }
-

--- a/src/schema/test-hotel-booking.json
+++ b/src/schema/test-hotel-booking.json
@@ -16,6 +16,7 @@
         },
         "options": {
             "typeRef": "#/domains/TestHotelBooking/types/Options",
+            "default": {},
             "initial": true,
             "description": "A set of options that define the automation's behaviour."
         },


### PR DESCRIPTION
Instead of setting always using `{}` as default for options input API
will use `default` value from input definition in protocol (or omit
setting default if input is not initial or default not defined).

https://docs.google.com/document/d/1zzx-CK2XyqsD1MfUAZXK7av1tKl_kM-SWyNEy44kkZ4/edit?pli=1

https://github.com/universalbasket/service-api/pull/836/commits/01b362127efa03a39e2ad1859286be703cd5bc31#diff-16d053f909bc3fd98b2536bfc2f2239dL53